### PR TITLE
feat: import MCP source + Playwright _electron smoke test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ pnpm-debug.log*
 # Test / coverage
 coverage/
 .nyc_output/
+test-results/
+playwright-report/
 
 # Misc
 .cache/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@nebula-agents/electron-mcp",
+  "version": "0.1.0-pre",
+  "description": "Embedded Model Context Protocol server for Electron apps. Exposes screenshot/evaluate/list_surfaces and friends over loopback HTTP, driving real BrowserWindows via webContents.debugger (CDP).",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/agent-labs-dev/electron-mcp.git"
+  },
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./types": {
+      "types": "./dist/types.d.ts",
+      "import": "./dist/types.js"
+    }
+  },
+  "files": [
+    "dist",
+    "LICENSE",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit",
+    "pretest": "pnpm build",
+    "test": "playwright test",
+    "test:smoke": "pnpm build && playwright test tests/smoke.electron.test.ts"
+  },
+  "peerDependencies": {
+    "@modelcontextprotocol/sdk": ">=1.29.0",
+    "electron": ">=30",
+    "zod": "^4.3.0"
+  },
+  "dependencies": {
+    "async-mutex": "^0.5.0"
+  },
+  "devDependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@playwright/test": "^1.49.0",
+    "@types/node": "^22.10.0",
+    "electron": "^41.2.1",
+    "playwright": "^1.49.0",
+    "typescript": "^5.7.2",
+    "zod": "^4.3.6"
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "@playwright/test";
+
+// `_electron.launch()` is exposed via `playwright` (not `@playwright/test`'s
+// browser pool). We only need the runner here — there's no browser fixture
+// to configure. Workers stay at 1 because each test spawns a real Electron
+// process and contends for the loopback port range.
+export default defineConfig({
+  testDir: "./tests",
+  testMatch: /.*\.electron\.test\.ts$/,
+  workers: 1,
+  fullyParallel: false,
+  reporter: process.env.CI ? "github" : "list",
+  // Smoke test launches Electron, attaches debugger, opens an MCP HTTP
+  // session — give it room on cold starts (CI-cached node_modules first
+  // run can take 10s+ just on Electron unpack).
+  timeout: 60_000,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,1360 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      async-mutex:
+        specifier: ^0.5.0
+        version: 0.5.0
+    devDependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.3.6)
+      '@playwright/test':
+        specifier: ^1.49.0
+        version: 1.59.1
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.17
+      electron:
+        specifier: ^41.2.1
+        version: 41.3.0
+      playwright:
+        specifier: ^1.49.0
+        version: 1.59.1
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+
+packages:
+
+  '@electron/get@2.0.3':
+    resolution: {integrity: sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==}
+    engines: {node: '>=12'}
+
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@sindresorhus/is@4.6.0':
+    resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
+    engines: {node: '>=10'}
+
+  '@szmarczak/http-timer@4.0.6':
+    resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
+    engines: {node: '>=10'}
+
+  '@types/cacheable-request@6.0.3':
+    resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
+
+  '@types/http-cache-semantics@4.2.0':
+    resolution: {integrity: sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==}
+
+  '@types/keyv@3.1.4':
+    resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
+
+  '@types/node@22.19.17':
+    resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
+
+  '@types/node@24.12.2':
+    resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
+
+  '@types/responselike@1.0.3':
+    resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
+
+  '@types/yauzl@2.10.3':
+    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
+
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
+  async-mutex@0.5.0:
+    resolution: {integrity: sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==}
+
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
+  boolean@3.2.0:
+    resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
+  buffer-crc32@0.2.13:
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
+  cacheable-lookup@5.0.4:
+    resolution: {integrity: sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==}
+    engines: {node: '>=10.6.0'}
+
+  cacheable-request@7.0.4:
+    resolution: {integrity: sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==}
+    engines: {node: '>=8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
+  clone-response@1.0.3:
+    resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
+
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
+  defer-to-connect@2.0.1:
+    resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
+    engines: {node: '>=10'}
+
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+
+  define-properties@1.2.1:
+    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
+    engines: {node: '>= 0.4'}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
+  detect-node@2.1.0:
+    resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  electron@41.3.0:
+    resolution: {integrity: sha512-2Q5aeocmFdeheZGDUTrAvSR3t+n0c3d104AJWWEnt7syJU0tE4VdibMYaPtQ47QuXSoUf0/xSsfUUvu/uSXIfg==}
+    engines: {node: '>= 12.20.55'}
+    hasBin: true
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es6-error@4.1.1:
+    resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
+  express-rate-limit@8.4.1:
+    resolution: {integrity: sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+
+  extract-zip@2.0.1:
+    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
+    engines: {node: '>= 10.17.0'}
+    hasBin: true
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fd-slicer@1.1.0:
+    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
+
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
+  fs-extra@8.1.0:
+    resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
+    engines: {node: '>=6 <7 || >=8'}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  get-stream@5.2.0:
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
+
+  global-agent@3.0.0:
+    resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
+    engines: {node: '>=10.0'}
+
+  globalthis@1.0.4:
+    resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
+    engines: {node: '>= 0.4'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  got@11.8.6:
+    resolution: {integrity: sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==}
+    engines: {node: '>=10.19.0'}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  hono@4.12.15:
+    resolution: {integrity: sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==}
+    engines: {node: '>=16.9.0'}
+
+  http-cache-semantics@4.2.0:
+    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  http2-wrapper@1.0.3:
+    resolution: {integrity: sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==}
+    engines: {node: '>=10.19.0'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jose@6.2.2:
+    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+
+  json-stringify-safe@5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+
+  jsonfile@4.0.0:
+    resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  lowercase-keys@2.0.0:
+    resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
+    engines: {node: '>=8'}
+
+  matcher@3.0.0:
+    resolution: {integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==}
+    engines: {node: '>=10'}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
+  mimic-response@1.0.1:
+    resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
+    engines: {node: '>=4'}
+
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
+  normalize-url@6.1.0:
+    resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
+    engines: {node: '>=10'}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  object-keys@1.1.1:
+    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
+    engines: {node: '>= 0.4'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  p-cancelable@2.1.1:
+    resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
+    engines: {node: '>=8'}
+
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
+  pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+    engines: {node: '>=0.6'}
+
+  quick-lru@5.1.1:
+    resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
+    engines: {node: '>=10'}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  resolve-alpn@1.2.1:
+    resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
+
+  responselike@2.0.1:
+    resolution: {integrity: sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==}
+
+  roarr@2.15.4:
+    resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
+    engines: {node: '>=8.0'}
+
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  semver-compare@1.0.0:
+    resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serialize-error@7.0.1:
+    resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
+    engines: {node: '>=10'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
+  sprintf-js@1.1.3:
+    resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
+  sumchecker@3.0.1:
+    resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
+    engines: {node: '>= 8.0'}
+
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  type-fest@0.13.1:
+    resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
+    engines: {node: '>=10'}
+
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  universalify@0.1.2:
+    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
+    engines: {node: '>= 4.0.0'}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  yauzl@2.10.0:
+    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+snapshots:
+
+  '@electron/get@2.0.3':
+    dependencies:
+      debug: 4.4.3
+      env-paths: 2.2.1
+      fs-extra: 8.1.0
+      got: 11.8.6
+      progress: 2.0.3
+      semver: 6.3.1
+      sumchecker: 3.0.1
+    optionalDependencies:
+      global-agent: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@hono/node-server@1.19.14(hono@4.12.15)':
+    dependencies:
+      hono: 4.12.15
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.15)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1
+      express-rate-limit: 8.4.1(express@5.2.1)
+      hono: 4.12.15
+      jose: 6.2.2
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
+
+  '@sindresorhus/is@4.6.0': {}
+
+  '@szmarczak/http-timer@4.0.6':
+    dependencies:
+      defer-to-connect: 2.0.1
+
+  '@types/cacheable-request@6.0.3':
+    dependencies:
+      '@types/http-cache-semantics': 4.2.0
+      '@types/keyv': 3.1.4
+      '@types/node': 22.19.17
+      '@types/responselike': 1.0.3
+
+  '@types/http-cache-semantics@4.2.0': {}
+
+  '@types/keyv@3.1.4':
+    dependencies:
+      '@types/node': 22.19.17
+
+  '@types/node@22.19.17':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/node@24.12.2':
+    dependencies:
+      undici-types: 7.16.0
+
+  '@types/responselike@1.0.3':
+    dependencies:
+      '@types/node': 22.19.17
+
+  '@types/yauzl@2.10.3':
+    dependencies:
+      '@types/node': 22.19.17
+    optional: true
+
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  async-mutex@0.5.0:
+    dependencies:
+      tslib: 2.8.1
+
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.1
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  boolean@3.2.0:
+    optional: true
+
+  buffer-crc32@0.2.13: {}
+
+  bytes@3.1.2: {}
+
+  cacheable-lookup@5.0.4: {}
+
+  cacheable-request@7.0.4:
+    dependencies:
+      clone-response: 1.0.3
+      get-stream: 5.2.0
+      http-cache-semantics: 4.2.0
+      keyv: 4.5.4
+      lowercase-keys: 2.0.0
+      normalize-url: 6.1.0
+      responselike: 2.0.1
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
+  clone-response@1.0.3:
+    dependencies:
+      mimic-response: 1.0.1
+
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
+  defer-to-connect@2.0.1: {}
+
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+    optional: true
+
+  define-properties@1.2.1:
+    dependencies:
+      define-data-property: 1.1.4
+      has-property-descriptors: 1.0.2
+      object-keys: 1.1.1
+    optional: true
+
+  depd@2.0.0: {}
+
+  detect-node@2.1.0:
+    optional: true
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ee-first@1.1.1: {}
+
+  electron@41.3.0:
+    dependencies:
+      '@electron/get': 2.0.3
+      '@types/node': 24.12.2
+      extract-zip: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  encodeurl@2.0.0: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
+
+  env-paths@2.2.1: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es6-error@4.1.1:
+    optional: true
+
+  escape-html@1.0.3: {}
+
+  escape-string-regexp@4.0.0:
+    optional: true
+
+  etag@1.8.1: {}
+
+  eventsource-parser@3.0.8: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.8
+
+  express-rate-limit@8.4.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.1.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.1
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  extract-zip@2.0.1:
+    dependencies:
+      debug: 4.4.3
+      get-stream: 5.2.0
+      yauzl: 2.10.0
+    optionalDependencies:
+      '@types/yauzl': 2.10.3
+    transitivePeerDependencies:
+      - supports-color
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-uri@3.1.0: {}
+
+  fd-slicer@1.1.0:
+    dependencies:
+      pend: 1.2.0
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
+  fs-extra@8.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 4.0.0
+      universalify: 0.1.2
+
+  fsevents@2.3.2:
+    optional: true
+
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
+  get-stream@5.2.0:
+    dependencies:
+      pump: 3.0.4
+
+  global-agent@3.0.0:
+    dependencies:
+      boolean: 3.2.0
+      es6-error: 4.1.1
+      matcher: 3.0.0
+      roarr: 2.15.4
+      semver: 7.7.4
+      serialize-error: 7.0.1
+    optional: true
+
+  globalthis@1.0.4:
+    dependencies:
+      define-properties: 1.2.1
+      gopd: 1.2.0
+    optional: true
+
+  gopd@1.2.0: {}
+
+  got@11.8.6:
+    dependencies:
+      '@sindresorhus/is': 4.6.0
+      '@szmarczak/http-timer': 4.0.6
+      '@types/cacheable-request': 6.0.3
+      '@types/responselike': 1.0.3
+      cacheable-lookup: 5.0.4
+      cacheable-request: 7.0.4
+      decompress-response: 6.0.0
+      http2-wrapper: 1.0.3
+      lowercase-keys: 2.0.0
+      p-cancelable: 2.1.1
+      responselike: 2.0.1
+
+  graceful-fs@4.2.11: {}
+
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
+    optional: true
+
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  hono@4.12.15: {}
+
+  http-cache-semantics@4.2.0: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
+  http2-wrapper@1.0.3:
+    dependencies:
+      quick-lru: 5.1.1
+      resolve-alpn: 1.2.1
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  inherits@2.0.4: {}
+
+  ip-address@10.1.0: {}
+
+  ipaddr.js@1.9.1: {}
+
+  is-promise@4.0.0: {}
+
+  isexe@2.0.0: {}
+
+  jose@6.2.2: {}
+
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
+
+  json-stringify-safe@5.0.1:
+    optional: true
+
+  jsonfile@4.0.0:
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
+  lowercase-keys@2.0.0: {}
+
+  matcher@3.0.0:
+    dependencies:
+      escape-string-regexp: 4.0.0
+    optional: true
+
+  math-intrinsics@1.1.0: {}
+
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
+  mimic-response@1.0.1: {}
+
+  mimic-response@3.1.0: {}
+
+  ms@2.1.3: {}
+
+  negotiator@1.0.0: {}
+
+  normalize-url@6.1.0: {}
+
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
+  object-keys@1.1.1:
+    optional: true
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  p-cancelable@2.1.1: {}
+
+  parseurl@1.3.3: {}
+
+  path-key@3.1.1: {}
+
+  path-to-regexp@8.4.2: {}
+
+  pend@1.2.0: {}
+
+  pkce-challenge@5.0.1: {}
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  progress@2.0.3: {}
+
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
+  qs@6.15.1:
+    dependencies:
+      side-channel: 1.1.0
+
+  quick-lru@5.1.1: {}
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
+
+  require-from-string@2.0.2: {}
+
+  resolve-alpn@1.2.1: {}
+
+  responselike@2.0.1:
+    dependencies:
+      lowercase-keys: 2.0.0
+
+  roarr@2.15.4:
+    dependencies:
+      boolean: 3.2.0
+      detect-node: 2.1.0
+      globalthis: 1.0.4
+      json-stringify-safe: 5.0.1
+      semver-compare: 1.0.0
+      sprintf-js: 1.1.3
+    optional: true
+
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
+  safer-buffer@2.1.2: {}
+
+  semver-compare@1.0.0:
+    optional: true
+
+  semver@6.3.1: {}
+
+  semver@7.7.4:
+    optional: true
+
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serialize-error@7.0.1:
+    dependencies:
+      type-fest: 0.13.1
+    optional: true
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
+  sprintf-js@1.1.3:
+    optional: true
+
+  statuses@2.0.2: {}
+
+  sumchecker@3.0.1:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  toidentifier@1.0.1: {}
+
+  tslib@2.8.1: {}
+
+  type-fest@0.13.1:
+    optional: true
+
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  undici-types@7.16.0: {}
+
+  universalify@0.1.2: {}
+
+  unpipe@1.0.0: {}
+
+  vary@1.1.2: {}
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  wrappy@1.0.2: {}
+
+  yauzl@2.10.0:
+    dependencies:
+      buffer-crc32: 0.2.13
+      fd-slicer: 1.1.0
+
+  zod-to-json-schema@3.25.2(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
+
+  zod@4.3.6: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+# Single-package repo (no `packages:` entry) — this file exists only to
+# allow-list build scripts. pnpm 10 moved `onlyBuiltDependencies` out of
+# package.json to here.
+onlyBuiltDependencies:
+  - electron

--- a/src/cdp-helpers.ts
+++ b/src/cdp-helpers.ts
@@ -1,0 +1,221 @@
+// Small CDP helpers shared by the input/DOM tool modules. ~100 LOC
+// of selector wait + keyboard mapping rather than a Playwright dep.
+
+import type { CdpSession } from "./cdp.js";
+
+// Coordinates in CSS pixels — what `Input.dispatchMouseEvent` expects.
+interface ElementRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  centerX: number;
+  centerY: number;
+}
+
+interface RuntimeEvaluateResult {
+  result: {
+    type: string;
+    value?: unknown;
+  };
+  exceptionDetails?: { text: string; exception?: { description?: string } };
+}
+
+// Zero-size elements are treated as not-present so `click` doesn't
+// dispatch at (0,0) on a mid-mount React element.
+export async function waitForSelector(
+  session: CdpSession,
+  selector: string,
+  timeoutMs: number,
+): Promise<ElementRect> {
+  const expression = `(() => {
+    const el = document.querySelector(${JSON.stringify(selector)});
+    if (!el) return null;
+    const r = el.getBoundingClientRect();
+    if (r.width === 0 || r.height === 0) return null;
+    return { x: r.x, y: r.y, width: r.width, height: r.height };
+  })()`;
+
+  // `performance.now()` (monotonic) so NTP/DST jumps don't skew us.
+  const start = performance.now();
+  while (performance.now() - start < timeoutMs) {
+    // Per-evaluate timeout — without it, a hung evaluate would
+    // outlive the outer `timeoutMs` gate.
+    const remainingMs = timeoutMs - (performance.now() - start);
+    const evalTimeoutMs = Math.max(1, Math.min(remainingMs, 1000));
+    const res = (await session.send("Runtime.evaluate", {
+      expression,
+      returnByValue: true,
+      timeout: evalTimeoutMs,
+    })) as RuntimeEvaluateResult;
+
+    if (res.exceptionDetails) {
+      // Parse errors etc. — propagate immediately rather than spin.
+      throw new Error(
+        `selector evaluation threw: ${res.exceptionDetails.exception?.description ?? res.exceptionDetails.text}`,
+      );
+    }
+
+    const v = res.result.value as {
+      x: number;
+      y: number;
+      width: number;
+      height: number;
+    } | null;
+    if (v) {
+      return {
+        x: v.x,
+        y: v.y,
+        width: v.width,
+        height: v.height,
+        centerX: v.x + v.width / 2,
+        centerY: v.y + v.height / 2,
+      };
+    }
+
+    await new Promise((r) => setTimeout(r, 50));
+  }
+
+  throw new Error(
+    `selector did not resolve to a visible element within ${timeoutMs}ms: ${selector}`,
+  );
+}
+
+// CDP modifier bitmask: alt=1, ctrl=2, meta/cmd=4, shift=8.
+const MODIFIER_BITS = {
+  alt: 1,
+  ctrl: 2,
+  control: 2,
+  meta: 4,
+  cmd: 4,
+  command: 4,
+  shift: 8,
+} as const;
+
+export type KeyModifier = keyof typeof MODIFIER_BITS;
+
+export function modifiersToMask(modifiers: readonly KeyModifier[]): number {
+  return modifiers.reduce((mask, mod) => mask | MODIFIER_BITS[mod], 0);
+}
+
+// v1 covers single printable ASCII + the named keys we actually
+// use; anything else throws — extending the tables is cheap.
+interface CdpKeyEvent {
+  key: string;
+  code: string;
+  windowsVirtualKeyCode?: number;
+  // Set for printable keys so `keyDown` inserts the char.
+  text?: string;
+}
+
+export function keyToCdp(
+  keyName: string,
+  modifiers: readonly KeyModifier[] = [],
+): CdpKeyEvent {
+  // Shallow-copy so callers can't mutate the shared NAMED_KEYS row.
+  const named = NAMED_KEYS[keyName];
+  if (named) return { ...named };
+
+  if (keyName.length === 1) {
+    const shifted = modifiers.includes("shift");
+    const base = keyName;
+    const isLetter = /^[A-Za-z]$/.test(base);
+    const isDigit = /^[0-9]$/.test(base);
+
+    // Apply shift to letters; layouts disagree on shifted punctuation
+    // so callers pass the shifted glyph directly through CHAR_CODES.
+    const ch = isLetter && shifted ? base.toUpperCase() : base;
+    const upper = ch.toUpperCase();
+
+    let code: string;
+    if (isLetter) {
+      code = `Key${upper}`;
+    } else if (isDigit) {
+      code = `Digit${ch}`;
+    } else {
+      const mapped = CHAR_CODES[ch];
+      if (!mapped) {
+        // Fail loud — an empty `code` breaks handlers that key off it.
+        throw new Error(
+          `unsupported key "${keyName}" — add it to CHAR_CODES or NAMED_KEYS in cdp-helpers.ts`,
+        );
+      }
+      code = mapped;
+    }
+
+    return {
+      key: ch,
+      code,
+      windowsVirtualKeyCode:
+        isLetter || isDigit ? upper.charCodeAt(0) : undefined,
+      text: ch,
+    };
+  }
+
+  throw new Error(
+    `unsupported key "${keyName}" — add it to NAMED_KEYS in cdp-helpers.ts`,
+  );
+}
+
+const NAMED_KEYS: Record<string, CdpKeyEvent> = {
+  Enter: { key: "Enter", code: "Enter", windowsVirtualKeyCode: 13, text: "\r" },
+  Escape: { key: "Escape", code: "Escape", windowsVirtualKeyCode: 27 },
+  Backspace: { key: "Backspace", code: "Backspace", windowsVirtualKeyCode: 8 },
+  Tab: { key: "Tab", code: "Tab", windowsVirtualKeyCode: 9, text: "\t" },
+  ArrowUp: { key: "ArrowUp", code: "ArrowUp", windowsVirtualKeyCode: 38 },
+  ArrowDown: { key: "ArrowDown", code: "ArrowDown", windowsVirtualKeyCode: 40 },
+  ArrowLeft: { key: "ArrowLeft", code: "ArrowLeft", windowsVirtualKeyCode: 37 },
+  ArrowRight: {
+    key: "ArrowRight",
+    code: "ArrowRight",
+    windowsVirtualKeyCode: 39,
+  },
+  Home: { key: "Home", code: "Home", windowsVirtualKeyCode: 36 },
+  End: { key: "End", code: "End", windowsVirtualKeyCode: 35 },
+  PageUp: { key: "PageUp", code: "PageUp", windowsVirtualKeyCode: 33 },
+  PageDown: { key: "PageDown", code: "PageDown", windowsVirtualKeyCode: 34 },
+  Delete: { key: "Delete", code: "Delete", windowsVirtualKeyCode: 46 },
+  " ": { key: " ", code: "Space", windowsVirtualKeyCode: 32, text: " " },
+  Space: { key: " ", code: "Space", windowsVirtualKeyCode: 32, text: " " },
+};
+
+// US layout: unshifted punctuation + shifted-digit row + common
+// shifted symbols. For text entry prefer `type_text` which sidesteps
+// physical-key mapping.
+const CHAR_CODES: Record<string, string> = {
+  // Unshifted punctuation
+  ".": "Period",
+  ",": "Comma",
+  ";": "Semicolon",
+  "'": "Quote",
+  "/": "Slash",
+  "\\": "Backslash",
+  "-": "Minus",
+  "=": "Equal",
+  "[": "BracketLeft",
+  "]": "BracketRight",
+  "`": "Backquote",
+  // Shifted digit row (US layout)
+  "!": "Digit1",
+  "@": "Digit2",
+  "#": "Digit3",
+  $: "Digit4",
+  "%": "Digit5",
+  "^": "Digit6",
+  "&": "Digit7",
+  "*": "Digit8",
+  "(": "Digit9",
+  ")": "Digit0",
+  // Shifted punctuation (US layout)
+  "<": "Comma",
+  ">": "Period",
+  "?": "Slash",
+  ":": "Semicolon",
+  '"': "Quote",
+  "|": "Backslash",
+  _: "Minus",
+  "+": "Equal",
+  "{": "BracketLeft",
+  "}": "BracketRight",
+  "~": "Backquote",
+};

--- a/src/cdp.ts
+++ b/src/cdp.ts
@@ -1,0 +1,127 @@
+// CDP via `webContents.debugger` — per-surface isolation, no always-
+// open loopback port in packaged builds, no Playwright dep. One
+// session cached per surface; `detachAll()` runs at will-quit.
+//
+// DevTools collision: `debugger.attach()` fails if DevTools are
+// already open, so we close them first (set NEBULA_OPEN_DEVTOOLS=0
+// for MCP-driven tests to skip the flicker).
+
+import type { BrowserWindow, WebContents } from "electron";
+import { resolveSurface, type SurfaceGetter } from "./surfaces.js";
+
+const CDP_PROTOCOL_VERSION = "1.3";
+
+// Narrow union for autocomplete; unknown methods still pass via `string`.
+type CdpMethod =
+  | "Runtime.enable"
+  | "Runtime.evaluate"
+  | "Page.enable"
+  | "Page.captureScreenshot"
+  | "DOM.enable"
+  | "DOM.getDocument"
+  | string;
+
+export interface CdpSession {
+  surface: string;
+  webContents: WebContents;
+  // Callers narrow the `unknown` response with `as <local-interface>`.
+  send: (
+    method: CdpMethod,
+    params?: Record<string, unknown>,
+  ) => Promise<unknown>;
+  detach: () => void;
+}
+
+interface AttachedRecord {
+  surface: string;
+  win: BrowserWindow;
+  teardownListener: () => void;
+}
+
+const attached = new Map<string, AttachedRecord>();
+
+export function getOrAttachSession(
+  getSurfaces: SurfaceGetter,
+  surface: string,
+): CdpSession {
+  const win = resolveSurface(getSurfaces, surface);
+  const wc = win.webContents;
+
+  const existing = attached.get(surface);
+  if (existing && !existing.win.isDestroyed() && wc.debugger.isAttached()) {
+    return buildSession(existing.surface, wc);
+  }
+
+  // Close auto-opened DevTools to avoid the attach conflict.
+  if (wc.isDevToolsOpened()) {
+    console.warn(
+      `[mcp] closing DevTools on "${surface}" surface so the CDP debugger can attach. ` +
+        `Set NEBULA_OPEN_DEVTOOLS=0 when running MCP-driven tests to skip the flicker.`,
+    );
+    wc.closeDevTools();
+  }
+
+  try {
+    wc.debugger.attach(CDP_PROTOCOL_VERSION);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `[mcp] debugger.attach failed for surface "${surface}": ${msg}`,
+    );
+  }
+
+  // Drop the cache on external detach (developer DevTools, another
+  // debugger, renderer crash) so the next call re-attaches cleanly.
+  const onDetach = (_event: Electron.Event, reason: string) => {
+    console.warn(
+      `[mcp] debugger detached from "${surface}" (reason: ${reason})`,
+    );
+    attached.delete(surface);
+  };
+  wc.debugger.on("detach", onDetach);
+
+  const record: AttachedRecord = {
+    surface,
+    win,
+    teardownListener: () => wc.debugger.off("detach", onDetach),
+  };
+  attached.set(surface, record);
+
+  return buildSession(surface, wc);
+}
+
+function buildSession(surface: string, wc: WebContents): CdpSession {
+  return {
+    surface,
+    webContents: wc,
+    send: async (method, params) => {
+      return wc.debugger.sendCommand(method, params ?? {});
+    },
+    detach: () => {
+      const rec = attached.get(surface);
+      if (rec) rec.teardownListener();
+      attached.delete(surface);
+      if (wc.debugger.isAttached()) {
+        try {
+          wc.debugger.detach();
+        } catch {
+          // Already detached — ignore.
+        }
+      }
+    },
+  };
+}
+
+export function detachAll(): void {
+  for (const [, rec] of attached) {
+    try {
+      rec.teardownListener();
+      if (!rec.win.isDestroyed() && rec.win.webContents.debugger.isAttached()) {
+        rec.win.webContents.debugger.detach();
+      }
+    } catch {
+      // Best-effort cleanup.
+    }
+  }
+  attached.clear();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,96 @@
+// Public entry: synchronous factory returning an explicit-lifecycle
+// handle. Gating (app.isPackaged, env opt-in, port parsing) lives in
+// the consumer (main.ts) — this module makes no assumptions about the
+// host process.
+
+import { Mutex } from "async-mutex";
+import { type RunningMcpServer, startMcpServer } from "./server.js";
+import type { SurfaceGetter, SurfaceMap } from "./surfaces.js";
+import type { ToolDef } from "./tool-def.js";
+
+export type { SurfaceGetter, SurfaceMap, ToolDef };
+
+interface ElectronMcpServerConfig {
+  getSurfaces: SurfaceGetter;
+  port?: number;
+  host?: string;
+  // Override server identity advertised in MCP `initialize`. Defaults
+  // to `{ name: "@nebula-agents/electron-mcp", version: "0.1.0" }`.
+  serverInfo?: { name: string; version: string };
+  // Override the `initialize.instructions` text shown to the client.
+  // Defaults to a generic "drives floating BrowserWindow surfaces"
+  // string baked into the package.
+  instructions?: string;
+}
+
+export interface ElectronMcpServerHandle {
+  // Register a consumer tool. Must be called BEFORE `start()`; throws
+  // afterwards. Tools registered here are bound to every per-session
+  // McpServer alongside the bundled tools.
+  addTool: (tool: ToolDef) => void;
+  start: () => Promise<void>;
+  stop: () => Promise<void>;
+  readonly isRunning: boolean;
+  // The bound URL once running, otherwise `null`. The port may be
+  // kernel-assigned when `config.port === 0`, so this is the source
+  // of truth (not the input config).
+  readonly url: string | null;
+}
+
+export function createElectronMcpServer(
+  config: ElectronMcpServerConfig,
+): ElectronMcpServerHandle {
+  const tools: ToolDef[] = [];
+  let running: RunningMcpServer | null = null;
+  // Single mutex serialises start/stop in both directions — without it
+  // an interleaving like start()→stop()-while-starting-resolves leaves
+  // the server up after the user thought stop() ran. Repo guideline
+  // (AGENTS.md) prefers `Mutex.runExclusive` over hand-rolled latches.
+  const lifecycle = new Mutex();
+  // `addTool` ordering is checked synchronously and so can't read
+  // `lifecycle.isLocked()` reliably (the lock state may flip between
+  // a concurrent call's check and the mutator). Track "start has been
+  // called at least once" with a flag; once true, addTool throws.
+  let startInvoked = false;
+
+  const handle: ElectronMcpServerHandle = {
+    addTool(tool) {
+      if (startInvoked) {
+        throw new Error(
+          `[mcp] addTool("${tool.name}") called after start() — register all tools before starting the server`,
+        );
+      }
+      tools.push(tool);
+    },
+    async start() {
+      startInvoked = true;
+      await lifecycle.runExclusive(async () => {
+        if (running !== null) return;
+        running = await startMcpServer({
+          getSurfaces: config.getSurfaces,
+          extraTools: tools,
+          port: config.port,
+          host: config.host,
+          serverInfo: config.serverInfo,
+          instructions: config.instructions,
+        });
+      });
+    },
+    async stop() {
+      await lifecycle.runExclusive(async () => {
+        if (running === null) return;
+        const current = running;
+        running = null;
+        await current.stop();
+      });
+    },
+    get isRunning() {
+      return running !== null;
+    },
+    get url() {
+      return running?.url ?? null;
+    },
+  };
+
+  return handle;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,420 @@
+// Streamable HTTP transport on `127.0.0.1` (not `localhost` — that
+// can resolve to IPv6). Bare `node:http` (no Express/Hono for one
+// route). No Origin check — the only path here is a localhost MCP
+// client and Claude Code doesn't send Origin anyway.
+
+import { randomUUID } from "node:crypto";
+import {
+  createServer,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from "node:http";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
+import { detachAll } from "./cdp.js";
+import type { SurfaceGetter } from "./surfaces.js";
+import type { ToolDef } from "./tool-def.js";
+import { registerAllTools } from "./tools/index.js";
+
+// Minimal stdout/stderr logger — extracted from nebula-desktop's
+// `@util/log` so this package has no internal-tooling dep. Consumers
+// that want structured logs can wrap stdout themselves.
+const log = {
+  info: (msg: string) => {
+    console.log(`[mcp] ${msg}`);
+  },
+  warn: (msg: string) => {
+    console.warn(`[mcp] ${msg}`);
+  },
+  error: (msg: string) => {
+    console.error(`[mcp] ${msg}`);
+  },
+};
+
+const DEFAULT_HOST = "127.0.0.1";
+const DEFAULT_PORT = 9229;
+const MCP_PATH = "/mcp";
+/** Retry once on EADDRINUSE — the previous Electron may still be releasing. */
+const EADDRINUSE_RETRY_DELAY_MS = 100;
+
+// Default `initialize` instructions sent to MCP clients. Generic, so the
+// embedded server is useful out of the box. Consumers can override via
+// `config.instructions` when they want app-specific guidance (which
+// surface names exist, when to reach for the tools, etc.).
+const DEFAULT_SERVER_INSTRUCTIONS = `\
+This server drives the floating BrowserWindow surfaces of a running
+Electron app. Reach for it to inspect or validate renderer-visible
+state — not for planning, not for main-process changes.
+
+Typical flow:
+  1. list_surfaces — discover which surfaces are live.
+  2. show_surface { surface: "<name>" } — bring the target into view.
+  3. screenshot { surface: "<name>" } to see the rendered result, or
+     evaluate { surface: "<name>", expression: "…" } to inspect state.
+
+Scope of \`evaluate\`: runs in the renderer MAIN WORLD.
+Reachable: document, window, React tree, your stores, fetch.
+NOT reachable: require("electron"), process, Node APIs.
+
+If a tool errors with "surface not available", the consumer Electron
+app isn't running or hasn't registered that surface yet.`;
+
+interface McpServerConfig {
+  getSurfaces: SurfaceGetter;
+  // Consumer-registered tools (e.g. an app's `trigger_hotkey`). Bound
+  // to every per-session McpServer alongside the bundled tools.
+  extraTools?: readonly ToolDef[];
+  // Pass `0` for an ephemeral port (used by tests).
+  port?: number;
+  // Only override to `::1` if you really want IPv6 loopback.
+  host?: string;
+  // Override server identity advertised in `initialize`. Defaults to
+  // `{ name: "@nebula-agents/electron-mcp", version: <pkg-version> }`.
+  serverInfo?: { name: string; version: string };
+  // Override the `initialize.instructions` text. Defaults to
+  // `DEFAULT_SERVER_INSTRUCTIONS` above.
+  instructions?: string;
+}
+
+export interface RunningMcpServer {
+  stop: () => Promise<void>;
+  url: string;
+}
+
+export async function startMcpServer(
+  config: McpServerConfig,
+): Promise<RunningMcpServer> {
+  const host = config.host ?? DEFAULT_HOST;
+  const port = config.port ?? DEFAULT_PORT;
+
+  // Hard loopback gate — anything else exposes evaluate/screenshot/
+  // CDP over the network.
+  if (host !== "127.0.0.1" && host !== "::1" && host !== "localhost") {
+    throw new Error(
+      `[mcp] refusing to bind non-loopback host "${host}" — only 127.0.0.1 / ::1 / localhost are allowed`,
+    );
+  }
+
+  // Per-session registry — `StreamableHTTPServerTransport` accepts
+  // only one session per lifetime, so we mint a fresh transport +
+  // McpServer pair per `initialize` (matches the SDK's multi-session
+  // example).
+  const sessions = new Map<string, Session>();
+
+  async function createSession(): Promise<Session> {
+    const sessionServer = new McpServer(
+      config.serverInfo ?? {
+        name: "@nebula-agents/electron-mcp",
+        version: "0.1.0",
+      },
+      {
+        capabilities: { tools: {} },
+        // Returned in `initialize`; shown every session.
+        instructions: config.instructions ?? DEFAULT_SERVER_INSTRUCTIONS,
+      },
+    );
+    registerAllTools(sessionServer, { getSurfaces: config.getSurfaces });
+    // The SDK's `registerTool` is generic over Zod schemas; our
+    // `ToolDef` widens those to `unknown` so consumers don't have to
+    // chase the SDK's compat-types. The runtime still validates the
+    // shape at registration time. Cast through `unknown` here, not by
+    // rebinding the method (would drop the `this` pointer to the
+    // McpServer's tool registry).
+    type LooseRegister = (
+      name: string,
+      config: ToolDef["config"],
+      handler: ToolDef["handler"],
+    ) => unknown;
+    for (const tool of config.extraTools ?? []) {
+      (sessionServer.registerTool as unknown as LooseRegister).call(
+        sessionServer,
+        tool.name,
+        tool.config,
+        tool.handler,
+      );
+    }
+
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+      onsessioninitialized: (sid) => {
+        sessions.set(sid, { transport, server: sessionServer });
+      },
+    });
+    let serverClosed = false;
+    transport.onclose = () => {
+      if (transport.sessionId) {
+        sessions.delete(transport.sessionId);
+      }
+      // Always close the paired server — pre-init disconnects would
+      // otherwise leak an orphan `McpServer` per failed connection.
+      // Re-entry guard: `McpServer.close()` calls `transport.close()`
+      // which fires this handler again. Without the latch the SDK
+      // recurses until the call stack overflows.
+      if (serverClosed) return;
+      serverClosed = true;
+      sessionServer.close().catch(() => {});
+    };
+    await sessionServer.connect(transport);
+    return { transport, server: sessionServer };
+  }
+
+  const httpServer = createServer(async (req, res) => {
+    try {
+      await routeRequest(req, res, sessions, createSession);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.error(`request failed: ${msg}`);
+      if (!res.headersSent) {
+        res.statusCode = 500;
+        res.setHeader("content-type", "application/json");
+        res.end(JSON.stringify({ error: msg }));
+      } else {
+        res.destroy();
+      }
+    }
+  });
+
+  try {
+    await listenWithRetry(httpServer, port, host);
+  } catch (err) {
+    httpServer.close();
+    throw err;
+  }
+
+  // `port: 0` resolves to a kernel-assigned ephemeral port (used by
+  // tests). Read it back from the bound socket so the URL is correct.
+  const address = httpServer.address();
+  const boundPort =
+    typeof address === "object" && address ? address.port : port;
+  // IPv6 literals must be bracketed in a URL authority — `http://::1:9229/mcp`
+  // is not parseable, `http://[::1]:9229/mcp` is.
+  const urlHost = host.includes(":") ? `[${host}]` : host;
+  const url = `http://${urlHost}:${boundPort}${MCP_PATH}`;
+  log.info(`listening on ${url}`);
+
+  return {
+    url,
+    stop: async () => {
+      detachAll();
+      // Snapshot — `server.close()` fires `transport.onclose` which
+      // mutates `sessions`.
+      const snapshot = [...sessions.values()];
+      sessions.clear();
+      for (const { server: sessionServer } of snapshot) {
+        await sessionServer.close().catch(() => {
+          // Best-effort — transport may already be torn down.
+        });
+      }
+      await new Promise<void>((resolve) => {
+        httpServer.close(() => resolve());
+      });
+    },
+  };
+}
+
+// JSON-RPC messages are tiny; cap the body to keep a rogue stream
+// from OOMing main.
+const MAX_BODY_BYTES = 4 * 1024 * 1024;
+
+interface Session {
+  transport: StreamableHTTPServerTransport;
+  server: McpServer;
+}
+
+async function routeRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  sessions: Map<string, Session>,
+  createSession: () => Promise<Session>,
+): Promise<void> {
+  const url = new URL(
+    req.url ?? "/",
+    `http://${req.headers.host ?? "localhost"}`,
+  );
+
+  if (url.pathname !== MCP_PATH) {
+    res.statusCode = 404;
+    res.setHeader("content-type", "application/json");
+    res.end(JSON.stringify({ error: `not found: ${url.pathname}` }));
+    return;
+  }
+
+  const headerSessionId = req.headers["mcp-session-id"];
+  const sessionId =
+    typeof headerSessionId === "string" ? headerSessionId : undefined;
+
+  if (req.method === "POST") {
+    const parsed = await readJsonBody(req);
+
+    // Discriminate on `ok` not body shape — a bare-string body like
+    // `"ping"` is valid JSON and must fall through to the normal
+    // not-an-initialize branch below.
+    if (!parsed.ok) {
+      if (parsed.reason === "too-large") {
+        res.statusCode = 413;
+        res.setHeader("content-type", "application/json");
+        // Pair with `socket.destroy()` below to terminate the
+        // upload after the response flushes.
+        res.setHeader("connection", "close");
+        res.end(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            error: {
+              code: -32600,
+              message: `Request body exceeds ${MAX_BODY_BYTES} bytes`,
+            },
+            id: null,
+          }),
+        );
+        req.socket?.destroy();
+        return;
+      }
+      res.statusCode = 400;
+      res.setHeader("content-type", "application/json");
+      res.end(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          error: { code: -32700, message: "Parse error" },
+          id: null,
+        }),
+      );
+      return;
+    }
+    const body = parsed.body;
+
+    if (sessionId) {
+      const existing = sessions.get(sessionId);
+      if (!existing) {
+        // Tell the client to re-initialize instead of retrying.
+        res.statusCode = 404;
+        res.setHeader("content-type", "application/json");
+        res.end(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            error: { code: -32001, message: "Unknown session" },
+            id: null,
+          }),
+        );
+        return;
+      }
+      await existing.transport.handleRequest(req, res, body);
+      return;
+    }
+
+    // First POST must be `initialize` — anything else would mint a
+    // zombie session.
+    if (isInitializeRequest(body)) {
+      const { transport } = await createSession();
+      await transport.handleRequest(req, res, body);
+      return;
+    }
+
+    res.statusCode = 400;
+    res.setHeader("content-type", "application/json");
+    res.end(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        error: {
+          code: -32000,
+          message:
+            "Bad Request: POST without Mcp-Session-Id must be initialize",
+        },
+        id: null,
+      }),
+    );
+    return;
+  }
+
+  // GET opens the SSE stream the server uses to push notifications;
+  // DELETE terminates the session. Both require an existing session ID.
+  if (req.method === "GET" || req.method === "DELETE") {
+    const existing = sessionId ? sessions.get(sessionId) : undefined;
+    if (!existing) {
+      res.statusCode = 400;
+      res.setHeader("content-type", "application/json");
+      res.end(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          error: { code: -32000, message: "Missing or invalid Mcp-Session-Id" },
+          id: null,
+        }),
+      );
+      return;
+    }
+    await existing.transport.handleRequest(req, res);
+    return;
+  }
+
+  res.statusCode = 405;
+  res.setHeader("content-type", "application/json");
+  res.end(JSON.stringify({ error: `method not allowed: ${req.method}` }));
+}
+
+// Branch on `ok`, not body shape — `"ping"` and `42` are valid
+// non-object bodies. Two failure reasons so the caller can pick
+// `400 -32700` (parse) vs `413` (too-large).
+type ReadJsonBodyResult =
+  | { ok: true; body: unknown }
+  | { ok: false; reason: "parse"; raw: string }
+  | { ok: false; reason: "too-large" };
+
+async function readJsonBody(req: IncomingMessage): Promise<ReadJsonBodyResult> {
+  let total = 0;
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as string);
+    total += buf.length;
+    if (total > MAX_BODY_BYTES) {
+      // Don't `req.destroy()` — that closes the socket before the
+      // 413 can flush. TCP backpressure stops the upload safely.
+      return { ok: false, reason: "too-large" };
+    }
+    chunks.push(buf);
+  }
+  if (chunks.length === 0) return { ok: true, body: null };
+  const text = Buffer.concat(chunks).toString("utf-8");
+  if (!text) return { ok: true, body: null };
+  try {
+    return { ok: true, body: JSON.parse(text) };
+  } catch {
+    return { ok: false, reason: "parse", raw: text };
+  }
+}
+
+// One 100ms retry papers over the brief port race when dev.mjs
+// kills + respawns Electron on main-bundle changes.
+function listenWithRetry(
+  httpServer: Server,
+  port: number,
+  host: string,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let retried = false;
+
+    const onError = (err: NodeJS.ErrnoException): void => {
+      if (err.code === "EADDRINUSE" && !retried) {
+        retried = true;
+        log.warn(
+          `port ${port} busy, retrying in ${EADDRINUSE_RETRY_DELAY_MS}ms…`,
+        );
+        setTimeout(() => {
+          httpServer.listen(port, host);
+        }, EADDRINUSE_RETRY_DELAY_MS);
+        return;
+      }
+      httpServer.off("listening", onListening);
+      reject(err);
+    };
+
+    const onListening = (): void => {
+      httpServer.off("error", onError);
+      resolve();
+    };
+
+    httpServer.on("error", onError);
+    httpServer.once("listening", onListening);
+    httpServer.listen(port, host);
+  });
+}

--- a/src/surfaces.ts
+++ b/src/surfaces.ts
@@ -1,0 +1,30 @@
+// Surface resolution for MCP tools. Uses an injected `getSurfaces()`
+// closure so the consumer owns the surface namespace — keys are
+// arbitrary strings (e.g. "bar", "tray", "main", "settings") and the
+// MCP module never hard-codes them.
+
+import type { BrowserWindow } from "electron";
+
+export type SurfaceMap = Record<string, BrowserWindow | null>;
+
+export type SurfaceGetter = () => SurfaceMap;
+
+class SurfaceNotFoundError extends Error {
+  constructor(surface: string) {
+    super(
+      `surface "${surface}" is not available (window not created or already destroyed)`,
+    );
+    this.name = "SurfaceNotFoundError";
+  }
+}
+
+export function resolveSurface(
+  getSurfaces: SurfaceGetter,
+  surface: string,
+): BrowserWindow {
+  const win = getSurfaces()[surface];
+  if (!win || win.isDestroyed()) {
+    throw new SurfaceNotFoundError(surface);
+  }
+  return win;
+}

--- a/src/tool-def.ts
+++ b/src/tool-def.ts
@@ -1,0 +1,31 @@
+// Public tool-definition shape for `addTool()`. Mirrors the args of
+// `McpServer.registerTool` from `@modelcontextprotocol/sdk` so a
+// consumer can build a tool with the SDK's types and hand it to us
+// without an extra adapter layer. This is the contract that will
+// extract verbatim into the future `@nebula-agents/electron-mcp/types`
+// sub-export.
+//
+// We can't lift the SDK's generic registerTool signature with
+// `Parameters<...>` (resolves to `never` for generic methods), and
+// chasing the full Zod-schema generic chain through public types would
+// pull half the SDK into our types. So we widen the schema fields to
+// `unknown` and the handler to a plain async function — the registry
+// doesn't enforce the schema↔handler-args relationship anyway, the SDK
+// does that at registration time when we forward to `registerTool`.
+
+import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+
+export interface ToolDef {
+  name: string;
+  config: {
+    title?: string;
+    description?: string;
+    // Either a `ZodRawShape` (record of zod schemas) or a JSON Schema
+    // object — the SDK accepts both. Widened to `unknown` here.
+    inputSchema?: unknown;
+    outputSchema?: unknown;
+    annotations?: ToolAnnotations;
+    _meta?: Record<string, unknown>;
+  };
+  handler: (...args: unknown[]) => unknown;
+}

--- a/src/tools/ax-snapshot.ts
+++ b/src/tools/ax-snapshot.ts
@@ -1,0 +1,179 @@
+// AX-tree snapshot via `Accessibility.getFullAXTree` — high-signal,
+// low-token UI description. The optional `root` selector prunes to
+// a subtree to stay under the 10k-token output soft-limit.
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { getOrAttachSession } from "../cdp.js";
+import type { SurfaceGetter } from "../surfaces.js";
+
+const inputSchema = {
+  surface: z.string().min(1).describe("Which surface to snapshot."),
+  root: z
+    .string()
+    .min(1)
+    .optional()
+    .describe(
+      "Optional CSS selector to scope the snapshot. Omit for the whole " +
+        "surface tree. Empty strings are rejected at validation time so " +
+        "they can't silently fall through to the full-tree path.",
+    ),
+  interestingOnly: z
+    .boolean()
+    .optional()
+    .describe(
+      "Drop uninteresting nodes (role=none, ignored wrappers, etc.) from " +
+        "the returned snapshot. Filtering happens locally on the JSON we " +
+        "ship back, not via CDP — `Accessibility.getFullAXTree` doesn't " +
+        "expose a server-side prune flag in our stable channel. Defaults " +
+        "to true — large savings, same information.",
+    ),
+};
+
+interface AxNode {
+  nodeId: string;
+  role?: { value: string };
+  name?: { value: string };
+  value?: { value?: unknown };
+  properties?: Array<{ name: string; value: { value: unknown } }>;
+  childIds?: string[];
+  backendDOMNodeId?: number;
+  ignored?: boolean;
+}
+
+interface GetFullAxTreeResponse {
+  nodes: AxNode[];
+}
+
+// RemoteObject lives at `.result`, not `.object`.
+interface RuntimeEvaluateObjectResponse {
+  result: { objectId?: string; subtype?: string; type: string };
+  exceptionDetails?: { text: string; exception?: { description?: string } };
+}
+
+interface RequestNodeResponse {
+  nodeId: number;
+}
+
+interface GetPartialAxTreeResponse {
+  nodes: AxNode[];
+}
+
+const ROOT_EVAL_TIMEOUT_MS = 5000;
+
+export function registerAxSnapshot(
+  server: McpServer,
+  getSurfaces: SurfaceGetter,
+): void {
+  server.registerTool(
+    "get_ax_snapshot",
+    {
+      title: "Accessibility-tree snapshot",
+      description:
+        "Capture the accessibility tree of a surface. Role + name + state " +
+        "for each node — much more compact than full DOM for describing " +
+        "UI to an LLM. Use before `click`/`type_text` to see what's " +
+        "actually on screen.",
+      inputSchema,
+    },
+    async ({ surface, root, interestingOnly = true }) => {
+      const session = getOrAttachSession(getSurfaces, surface);
+      // Re-enable each call; pair with `disable` in `finally` —
+      // leaving AX on has ongoing page-perf cost.
+      await session.send("Accessibility.enable");
+      try {
+        if (root) {
+          // Resolve via Runtime.evaluate → DOM.requestNode →
+          // Accessibility.getPartialAXTree.
+          const evalRes = (await session.send("Runtime.evaluate", {
+            expression: `document.querySelector(${JSON.stringify(root)})`,
+            timeout: ROOT_EVAL_TIMEOUT_MS,
+          })) as RuntimeEvaluateObjectResponse;
+          if (evalRes.exceptionDetails || !evalRes.result.objectId) {
+            const reason =
+              evalRes.exceptionDetails?.exception?.description ??
+              evalRes.exceptionDetails?.text ??
+              "selector returned null";
+            return {
+              isError: true,
+              content: [
+                {
+                  type: "text",
+                  text: `root selector not resolvable: ${root} (${reason})`,
+                },
+              ],
+            };
+          }
+          // Release the evaluate handle in `finally` so we don't
+          // accumulate stale objectIds across snapshots.
+          const objectId = evalRes.result.objectId;
+          try {
+            const reqRes = (await session.send("DOM.requestNode", {
+              objectId,
+            })) as RequestNodeResponse;
+            const partial = (await session.send(
+              "Accessibility.getPartialAXTree",
+              { nodeId: reqRes.nodeId, fetchRelatives: true },
+            )) as GetPartialAxTreeResponse;
+            return formatTree(surface, partial.nodes, {
+              interestingOnly,
+              root,
+            });
+          } finally {
+            // Best-effort cleanup — don't shadow the real result.
+            void session
+              .send("Runtime.releaseObject", { objectId })
+              .catch(() => {});
+          }
+        }
+
+        const full = (await session.send(
+          "Accessibility.getFullAXTree",
+          {},
+        )) as GetFullAxTreeResponse;
+        return formatTree(surface, full.nodes, { interestingOnly });
+      } finally {
+        void session.send("Accessibility.disable").catch(() => {});
+      }
+    },
+  );
+}
+
+function formatTree(
+  surface: string,
+  nodes: AxNode[],
+  opts: { interestingOnly: boolean; root?: string },
+) {
+  const filtered = opts.interestingOnly
+    ? nodes.filter((n) => !n.ignored && n.role?.value !== "none")
+    : nodes;
+
+  // Drop childIds pointing at filtered-out nodes so the tree stays
+  // internally consistent for traversals.
+  const keptIds = new Set(filtered.map((n) => n.nodeId));
+
+  const simplified = filtered.map((n) => {
+    const props: Record<string, unknown> = {};
+    for (const p of n.properties ?? []) {
+      props[p.name] = p.value.value;
+    }
+    return {
+      id: n.nodeId,
+      role: n.role?.value ?? null,
+      name: n.name?.value ?? null,
+      value: n.value?.value ?? null,
+      properties: props,
+      children: (n.childIds ?? []).filter((id) => keptIds.has(id)),
+    };
+  });
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: `AX snapshot (${simplified.length} nodes${opts.root ? `, scoped to ${opts.root}` : ""}):\n${JSON.stringify(simplified, null, 2)}`,
+      },
+    ],
+    structuredContent: { surface, root: opts.root ?? null, nodes: simplified },
+  };
+}

--- a/src/tools/click.ts
+++ b/src/tools/click.ts
@@ -1,0 +1,91 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { getOrAttachSession } from "../cdp.js";
+import { waitForSelector } from "../cdp-helpers.js";
+import { resolveSurface, type SurfaceGetter } from "../surfaces.js";
+
+const inputSchema = {
+  surface: z.string().min(1).describe("Which surface to click in."),
+  selector: z
+    .string()
+    .min(1)
+    .describe(
+      "CSS selector for the click target. Must match at least one " +
+        "element; if multiple elements match, the first match is clicked.",
+    ),
+  button: z
+    .enum(["left", "right", "middle"])
+    .optional()
+    .describe("Mouse button. Defaults to left."),
+  clickCount: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe("Click count (2 = double-click). Defaults to 1."),
+  timeoutMs: z
+    .number()
+    .int()
+    .positive()
+    .max(60_000)
+    .optional()
+    .describe("Wait-for-selector timeout in ms (1-60000). Defaults to 5000."),
+};
+
+export function registerClick(
+  server: McpServer,
+  getSurfaces: SurfaceGetter,
+): void {
+  server.registerTool(
+    "click",
+    {
+      title: "Click element",
+      description:
+        "Click an element matching a CSS selector. Auto-waits up to " +
+        "timeoutMs for the element to exist and have non-zero size before " +
+        "dispatching a mousedown + mouseup at its center.",
+      inputSchema,
+    },
+    async ({
+      surface,
+      selector,
+      button = "left",
+      clickCount = 1,
+      timeoutMs = 5000,
+    }) => {
+      // Show the window: CDP dispatches regardless of visibility,
+      // but a hidden window won't paint hover/layout state. We don't
+      // focus here — `focus_surface` is the right tool for that.
+      const win = resolveSurface(getSurfaces, surface);
+      if (!win.isVisible()) win.show();
+
+      const session = getOrAttachSession(getSurfaces, surface);
+      const rect = await waitForSelector(session, selector, timeoutMs);
+
+      const common = {
+        x: rect.centerX,
+        y: rect.centerY,
+        button,
+        clickCount,
+      };
+      await session.send("Input.dispatchMouseEvent", {
+        ...common,
+        type: "mousePressed",
+      });
+      await session.send("Input.dispatchMouseEvent", {
+        ...common,
+        type: "mouseReleased",
+      });
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Clicked ${selector} on ${surface} at (${Math.round(rect.centerX)}, ${Math.round(rect.centerY)})`,
+          },
+        ],
+        structuredContent: { surface, selector, rect, button, clickCount },
+      };
+    },
+  );
+}

--- a/src/tools/evaluate.ts
+++ b/src/tools/evaluate.ts
@@ -1,0 +1,121 @@
+// `evaluate` runs in the renderer main world. Scope caveats live in
+// the tool's MCP description so the agent reads them every session.
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { getOrAttachSession } from "../cdp.js";
+import type { SurfaceGetter } from "../surfaces.js";
+
+const inputSchema = {
+  surface: z
+    .string()
+    .min(1)
+    .describe("Which surface's renderer to evaluate in."),
+  expression: z
+    .string()
+    .describe(
+      "JavaScript to evaluate. Must be a single expression (wrap multiple " +
+        "statements in an IIFE). Runs in the renderer main world.",
+    ),
+  awaitPromise: z
+    .boolean()
+    .optional()
+    .describe(
+      "Await the evaluation's promise before returning. Defaults to true.",
+    ),
+  returnByValue: z
+    .boolean()
+    .optional()
+    .describe(
+      "Serialize the result as JSON instead of returning a remote-object " +
+        "handle. Defaults to true; pass false only if you need the handle.",
+    ),
+  timeoutMs: z
+    .number()
+    .int()
+    .positive()
+    .max(60_000)
+    .optional()
+    .describe("Evaluation timeout in ms (1-60000). Defaults to 5000."),
+};
+
+interface RuntimeEvaluateResult {
+  result: {
+    type: string;
+    subtype?: string;
+    value?: unknown;
+    description?: string;
+    unserializableValue?: string;
+  };
+  exceptionDetails?: {
+    exceptionId: number;
+    text: string;
+    lineNumber: number;
+    columnNumber: number;
+    exception?: { description?: string; value?: unknown };
+  };
+}
+
+export function registerEvaluate(
+  server: McpServer,
+  getSurfaces: SurfaceGetter,
+): void {
+  server.registerTool(
+    "evaluate",
+    {
+      title: "Evaluate JS in renderer",
+      description:
+        "Run JavaScript in the specified surface's renderer main world via " +
+        "CDP Runtime.evaluate. Returns the value (JSON-serialized) or an " +
+        "exception description. Main-world scope: DOM, React, Zustand, and " +
+        "window.nebula are reachable; Node/Electron APIs are not.",
+      inputSchema,
+    },
+    async ({
+      surface,
+      expression,
+      awaitPromise = true,
+      returnByValue = true,
+      timeoutMs = 5000,
+    }) => {
+      const session = getOrAttachSession(getSurfaces, surface);
+      const res = (await session.send("Runtime.evaluate", {
+        expression,
+        awaitPromise,
+        returnByValue,
+        timeout: timeoutMs,
+        generatePreview: true, // string form for non-serializable
+        userGesture: true, // autoplay/clipboard gates
+      })) as RuntimeEvaluateResult;
+
+      if (res.exceptionDetails) {
+        const exc = res.exceptionDetails;
+        const summary =
+          exc.exception?.description ?? exc.text ?? "unknown exception";
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: `Evaluation threw at ${exc.lineNumber}:${exc.columnNumber}\n${summary}`,
+            },
+          ],
+          structuredContent: { exception: exc },
+        };
+      }
+
+      const value = res.result.value;
+      const text =
+        value === undefined
+          ? (res.result.description ?? String(res.result.type))
+          : typeof value === "string"
+            ? value
+            : JSON.stringify(value, null, 2);
+
+      return {
+        content: [{ type: "text", text }],
+        structuredContent: { result: res.result },
+      };
+    },
+  );
+}

--- a/src/tools/fill-form.ts
+++ b/src/tools/fill-form.ts
@@ -1,0 +1,259 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { type CdpSession, getOrAttachSession } from "../cdp.js";
+import { waitForSelector } from "../cdp-helpers.js";
+import { resolveSurface, type SurfaceGetter } from "../surfaces.js";
+
+interface RuntimeEvaluateAssertResult {
+  result: { value?: { ok: boolean; reason?: string } };
+  exceptionDetails?: { text: string; exception?: { description?: string } };
+}
+
+// Throws if the evaluated expression threw OR returned `{ ok: false }`.
+// CDP reports throws via `exceptionDetails` (not promise rejection),
+// so a naive throw-inside-evaluate would silently swallow.
+async function assertEvaluate(
+  session: CdpSession,
+  expression: string,
+  timeoutMs: number,
+): Promise<void> {
+  const res = (await session.send("Runtime.evaluate", {
+    expression,
+    returnByValue: true,
+    timeout: timeoutMs,
+  })) as RuntimeEvaluateAssertResult;
+
+  if (res.exceptionDetails) {
+    throw new Error(
+      `evaluate threw: ${res.exceptionDetails.exception?.description ?? res.exceptionDetails.text}`,
+    );
+  }
+  const value = res.result.value;
+  if (!value || value.ok !== true) {
+    throw new Error(
+      value?.reason ?? "evaluate returned non-ok without a reason",
+    );
+  }
+}
+
+const fieldSchema = z.object({
+  selector: z.string().min(1).describe("CSS selector for the field."),
+  value: z.string().describe("Value to insert."),
+});
+
+const inputSchema = {
+  surface: z.string().min(1).describe("Which surface to fill the form on."),
+  fields: z
+    .array(fieldSchema)
+    .min(1)
+    .describe("Ordered list of selector → value pairs to fill in sequence."),
+  clearFirst: z
+    .boolean()
+    .optional()
+    .describe(
+      "If true (default), select-all existing text in each field before " +
+        "inserting the new value (replace). If false, move the caret to " +
+        "the end of the existing content first so the new value cleanly " +
+        "appends — without this, the post-click caret could land mid-text " +
+        "and `Input.insertText` would splice in the middle.",
+    ),
+  timeoutMs: z
+    .number()
+    .int()
+    .positive()
+    .max(60_000)
+    .optional()
+    .describe(
+      "Wait-for-selector timeout per field (1-60000 ms). Defaults to 5000.",
+    ),
+};
+
+export function registerFillForm(
+  server: McpServer,
+  getSurfaces: SurfaceGetter,
+): void {
+  server.registerTool(
+    "fill_form",
+    {
+      title: "Fill multiple form fields",
+      description:
+        "Fill a sequence of fields in one call. Per field: wait for the " +
+        "selector, focus it, optionally clear existing text, then insert " +
+        "the new value via CDP Input.insertText. Fails fast with the " +
+        "failing field's index on any error.",
+      inputSchema,
+    },
+    async ({ surface, fields, clearFirst = true, timeoutMs = 5000 }) => {
+      // Show the window — same reasoning as in `click`.
+      const win = resolveSurface(getSurfaces, surface);
+      if (!win.isVisible()) win.show();
+
+      const session = getOrAttachSession(getSurfaces, surface);
+      const filled: Array<{ selector: string; ok: true }> = [];
+
+      for (const [i, field] of fields.entries()) {
+        try {
+          const rect = await waitForSelector(
+            session,
+            field.selector,
+            timeoutMs,
+          );
+
+          // Click (not .focus()) so focus-ring behavior matches a
+          // real user click.
+          await session.send("Input.dispatchMouseEvent", {
+            type: "mousePressed",
+            x: rect.centerX,
+            y: rect.centerY,
+            button: "left",
+            clickCount: 1,
+          });
+          await session.send("Input.dispatchMouseEvent", {
+            type: "mouseReleased",
+            x: rect.centerX,
+            y: rect.centerY,
+            button: "left",
+            clickCount: 1,
+          });
+
+          // Verify the click landed on (or inside, for wrappers) the
+          // target — an intercepting overlay would otherwise route
+          // the next `insertText` to the wrong field silently.
+          await assertEvaluate(
+            session,
+            `(() => {
+              const el = document.querySelector(${JSON.stringify(field.selector)});
+              if (!el) return { ok: false, reason: "target element disappeared before typing" };
+              const active = document.activeElement;
+              const focused =
+                active === el || (active instanceof Node && el.contains(active));
+              return focused
+                ? { ok: true }
+                : { ok: false, reason: "click did not land focus on target — likely intercepted by an overlay" };
+            })()`,
+            timeoutMs,
+          );
+
+          if (clearFirst) {
+            // select-all + insertText replace, cross-platform without
+            // a Cmd+A / Ctrl+A dispatch. Falls through to a
+            // Range-based select-all for contenteditable; throws on
+            // an unclearable target so misuse can't fail silently.
+            await assertEvaluate(
+              session,
+              `(() => {
+                const el = document.querySelector(${JSON.stringify(field.selector)});
+                if (!el) return { ok: false, reason: "target element disappeared before clearFirst" };
+                const isClearable = (n) =>
+                  !!n && (typeof n.select === "function" ||
+                          (n instanceof HTMLElement && n.isContentEditable));
+                const active = document.activeElement;
+                const target =
+                  isClearable(el)
+                    ? el
+                    : active instanceof Element && el.contains(active) && isClearable(active)
+                      ? active
+                      : null;
+                if (!target) {
+                  return { ok: false, reason: "clearFirst requires <input>, <textarea>, or [contenteditable] (matched element or focused descendant)" };
+                }
+                if (typeof target.select === "function") {
+                  target.select();
+                } else {
+                  const range = document.createRange();
+                  range.selectNodeContents(target);
+                  const sel = getSelection();
+                  sel?.removeAllRanges();
+                  sel?.addRange(range);
+                }
+                return { ok: true };
+              })()`,
+              timeoutMs,
+            );
+          } else {
+            // Append intent: collapse the caret to end so the click
+            // landing mid-text doesn't splice the new value in.
+            await assertEvaluate(
+              session,
+              `(() => {
+                const el = document.querySelector(${JSON.stringify(field.selector)});
+                if (!el) return { ok: false, reason: "target element disappeared before append" };
+                const isTextField = (n) =>
+                  n instanceof HTMLInputElement ||
+                  n instanceof HTMLTextAreaElement;
+                const isContentEditable = (n) =>
+                  n instanceof HTMLElement && n.isContentEditable;
+                const active = document.activeElement;
+                const target =
+                  isTextField(el) || isContentEditable(el)
+                    ? el
+                    : active instanceof Element &&
+                        el.contains(active) &&
+                        (isTextField(active) || isContentEditable(active))
+                      ? active
+                      : null;
+                if (!target) {
+                  // Non-text-bearing target: nothing to append to.
+                  // insertText will dispatch to whatever has focus,
+                  // which is the closest reasonable behaviour without
+                  // forcing a particular caret semantic.
+                  return { ok: true };
+                }
+                if (isTextField(target)) {
+                  const end = target.value.length;
+                  target.setSelectionRange(end, end);
+                } else {
+                  const range = document.createRange();
+                  range.selectNodeContents(target);
+                  range.collapse(false); // collapse to end
+                  const sel = getSelection();
+                  sel?.removeAllRanges();
+                  sel?.addRange(range);
+                }
+                return { ok: true };
+              })()`,
+              timeoutMs,
+            );
+          }
+
+          await session.send("Input.insertText", { text: field.value });
+          filled.push({ selector: field.selector, ok: true });
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text",
+                text: `fill_form failed at field ${i} (${field.selector}): ${msg}\n${filled.length} earlier field(s) filled before the failure.`,
+              },
+            ],
+            structuredContent: {
+              surface,
+              failedIndex: i,
+              failedSelector: field.selector,
+              filledCount: filled.length,
+              filled,
+              error: msg,
+            },
+          };
+        }
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Filled ${filled.length} field(s) on ${surface}`,
+          },
+        ],
+        structuredContent: {
+          surface,
+          filledCount: filled.length,
+          filled,
+          clearFirst,
+        },
+      };
+    },
+  );
+}

--- a/src/tools/focus-surface.ts
+++ b/src/tools/focus-surface.ts
@@ -1,0 +1,61 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { resolveSurface, type SurfaceGetter } from "../surfaces.js";
+
+const inputSchema = {
+  surface: z.string().min(1).describe("Which surface to focus."),
+};
+
+export function registerFocusSurface(
+  server: McpServer,
+  getSurfaces: SurfaceGetter,
+): void {
+  server.registerTool(
+    "focus_surface",
+    {
+      title: "Focus surface",
+      description:
+        "Give keyboard focus to a floating surface. Returns an explicit " +
+        "error if the window is currently non-focusable rather than a " +
+        "silent no-op.",
+      inputSchema,
+    },
+    async ({ surface }) => {
+      const win = resolveSurface(getSurfaces, surface);
+
+      if (!win.isFocusable()) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: `Surface "${surface}" is currently non-focusable; focus call ignored.`,
+            },
+          ],
+          structuredContent: {
+            surface,
+            focused: false,
+            focusable: false,
+            visible: win.isVisible(),
+          },
+        };
+      }
+
+      win.focus();
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Focused ${surface}. focused=${win.isFocused()}`,
+          },
+        ],
+        structuredContent: {
+          surface,
+          focused: win.isFocused(),
+          focusable: true,
+          visible: win.isVisible(),
+        },
+      };
+    },
+  );
+}

--- a/src/tools/hide-surface.ts
+++ b/src/tools/hide-surface.ts
@@ -1,0 +1,36 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { resolveSurface, type SurfaceGetter } from "../surfaces.js";
+
+const inputSchema = {
+  surface: z.string().min(1).describe("Which surface to hide."),
+};
+
+export function registerHideSurface(
+  server: McpServer,
+  getSurfaces: SurfaceGetter,
+): void {
+  server.registerTool(
+    "hide_surface",
+    {
+      title: "Hide surface",
+      description:
+        "Hide a floating surface. No-op if already hidden. Pairs with " +
+        "show_surface.",
+      inputSchema,
+    },
+    async ({ surface }) => {
+      const win = resolveSurface(getSurfaces, surface);
+      win.hide();
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Hidden ${surface}. visible=${win.isVisible()}`,
+          },
+        ],
+        structuredContent: { surface, visible: win.isVisible() },
+      };
+    },
+  );
+}

--- a/src/tools/hover.ts
+++ b/src/tools/hover.ts
@@ -1,0 +1,64 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { getOrAttachSession } from "../cdp.js";
+import { waitForSelector } from "../cdp-helpers.js";
+import { resolveSurface, type SurfaceGetter } from "../surfaces.js";
+
+const inputSchema = {
+  surface: z.string().min(1).describe("Which surface to hover in."),
+  selector: z
+    .string()
+    .min(1)
+    .describe(
+      "CSS selector for the hover target. Must match at least one " +
+        "element; if multiple elements match, the first match is hovered.",
+    ),
+  timeoutMs: z
+    .number()
+    .int()
+    .positive()
+    .max(60_000)
+    .optional()
+    .describe("Wait-for-selector timeout in ms (1-60000). Defaults to 5000."),
+};
+
+export function registerHover(
+  server: McpServer,
+  getSurfaces: SurfaceGetter,
+): void {
+  server.registerTool(
+    "hover",
+    {
+      title: "Hover element",
+      description:
+        "Move the cursor over an element matching a CSS selector. Fires " +
+        "mouseenter/mouseover events at the element center. Useful for " +
+        "revealing tooltips and dropdowns before inspecting them.",
+      inputSchema,
+    },
+    async ({ surface, selector, timeoutMs = 5000 }) => {
+      // Show the window — hover UI won't paint on a hidden window.
+      const win = resolveSurface(getSurfaces, surface);
+      if (!win.isVisible()) win.show();
+
+      const session = getOrAttachSession(getSurfaces, surface);
+      const rect = await waitForSelector(session, selector, timeoutMs);
+
+      await session.send("Input.dispatchMouseEvent", {
+        type: "mouseMoved",
+        x: rect.centerX,
+        y: rect.centerY,
+      });
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Hovered ${selector} on ${surface} at (${Math.round(rect.centerX)}, ${Math.round(rect.centerY)})`,
+          },
+        ],
+        structuredContent: { surface, selector, rect },
+      };
+    },
+  );
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,0 +1,50 @@
+// Generic MCP tool barrel — surface-agnostic, no app-specific
+// callbacks. App-specific tools (`trigger_hotkey`, `trigger_tray_click`)
+// live under `../app-tools/` and are registered by the consumer.
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { SurfaceGetter } from "../surfaces.js";
+import { registerAxSnapshot } from "./ax-snapshot.js";
+import { registerClick } from "./click.js";
+import { registerEvaluate } from "./evaluate.js";
+import { registerFillForm } from "./fill-form.js";
+import { registerFocusSurface } from "./focus-surface.js";
+import { registerHideSurface } from "./hide-surface.js";
+import { registerHover } from "./hover.js";
+import { registerListSurfaces } from "./list-surfaces.js";
+import { registerPressKey } from "./press-key.js";
+import { registerQueryDom } from "./query-dom.js";
+import { registerReloadSurface } from "./reload-surface.js";
+import { registerScreenshot } from "./screenshot.js";
+import { registerShowSurface } from "./show-surface.js";
+import { registerTypeText } from "./type-text.js";
+import { registerWaitForLoad } from "./wait-for-load.js";
+
+interface RegisterAllToolsOptions {
+  getSurfaces: SurfaceGetter;
+}
+
+export function registerAllTools(
+  server: McpServer,
+  options: RegisterAllToolsOptions,
+): void {
+  const { getSurfaces } = options;
+
+  registerListSurfaces(server, getSurfaces);
+  registerShowSurface(server, getSurfaces);
+  registerEvaluate(server, getSurfaces);
+  registerScreenshot(server, getSurfaces);
+
+  registerClick(server, getSurfaces);
+  registerTypeText(server, getSurfaces);
+  registerPressKey(server, getSurfaces);
+  registerQueryDom(server, getSurfaces);
+  registerAxSnapshot(server, getSurfaces);
+  registerHideSurface(server, getSurfaces);
+  registerFocusSurface(server, getSurfaces);
+
+  registerHover(server, getSurfaces);
+  registerFillForm(server, getSurfaces);
+  registerReloadSurface(server, getSurfaces);
+  registerWaitForLoad(server, getSurfaces);
+}

--- a/src/tools/list-surfaces.ts
+++ b/src/tools/list-surfaces.ts
@@ -1,0 +1,52 @@
+// Pure main-process inspection — no CDP attach. Destroyed surfaces
+// are reported as `present: false` (not omitted) so the agent sees
+// "missing" instead of silently inferring it.
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { SurfaceGetter } from "../surfaces.js";
+
+export function registerListSurfaces(
+  server: McpServer,
+  getSurfaces: SurfaceGetter,
+): void {
+  server.registerTool(
+    "list_surfaces",
+    {
+      title: "List surfaces",
+      description:
+        "Enumerate every floating surface registered by the consumer with " +
+        "its current visibility, focused state, screen bounds, and " +
+        "webContents id. Use this to discover which surfaces are live " +
+        "before calling any other tool.",
+    },
+    async () => {
+      const surfaces = getSurfaces();
+      const entries = Object.keys(surfaces)
+        .sort()
+        .map((name) => describeSurface(name, surfaces[name] ?? null));
+      return {
+        content: [{ type: "text", text: JSON.stringify(entries, null, 2) }],
+        structuredContent: { surfaces: entries },
+      };
+    },
+  );
+}
+
+function describeSurface(name: string, win: Electron.BrowserWindow | null) {
+  if (!win || win.isDestroyed()) {
+    return { surface: name, present: false } as const;
+  }
+  const bounds = win.getBounds();
+  return {
+    surface: name,
+    present: true,
+    visible: win.isVisible(),
+    focused: win.isFocused(),
+    focusable: win.isFocusable(),
+    alwaysOnTop: win.isAlwaysOnTop(),
+    bounds,
+    webContentsId: win.webContents.id,
+    url: win.webContents.getURL(),
+    devToolsOpen: win.webContents.isDevToolsOpened(),
+  } as const;
+}

--- a/src/tools/press-key.ts
+++ b/src/tools/press-key.ts
@@ -1,0 +1,110 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { getOrAttachSession } from "../cdp.js";
+import { type KeyModifier, keyToCdp, modifiersToMask } from "../cdp-helpers.js";
+import type { SurfaceGetter } from "../surfaces.js";
+
+const MODIFIER_VALUES = [
+  "alt",
+  "ctrl",
+  "control",
+  "meta",
+  "cmd",
+  "command",
+  "shift",
+] as const satisfies readonly KeyModifier[];
+
+const inputSchema = {
+  surface: z.string().min(1).describe("Which surface to press the key on."),
+  key: z
+    .string()
+    .min(1)
+    .describe(
+      "Key name. Single printable characters (a-z, 0-9, symbols) or named " +
+        "keys: Enter, Escape, Backspace, Tab, ArrowUp/Down/Left/Right, " +
+        "Home, End, PageUp, PageDown, Delete, Space. For shifted glyphs " +
+        "(`!`, `@`, `?`, …), pass the final glyph directly — `shift` in " +
+        "`modifiers` is only auto-applied for ASCII letters, not for " +
+        "shifted digits/punctuation, since the shifted-glyph mapping is " +
+        "keyboard-layout-dependent.",
+    ),
+  modifiers: z
+    .array(z.enum(MODIFIER_VALUES))
+    .optional()
+    .describe(
+      "Modifier keys held while the key is pressed. Uses common aliases: " +
+        "cmd/meta/command are equivalent; ctrl/control; alt; shift. See " +
+        "`key` above for the shift-on-non-letters caveat.",
+    ),
+};
+
+// Preserve first-seen order so the response echoes the caller's
+// intent (e.g. `["shift", "cmd"]` stays in that order).
+function normalizeModifiers(modifiers: readonly KeyModifier[]): KeyModifier[] {
+  const canon: Record<KeyModifier, KeyModifier> = {
+    alt: "alt",
+    ctrl: "ctrl",
+    control: "ctrl",
+    meta: "cmd",
+    cmd: "cmd",
+    command: "cmd",
+    shift: "shift",
+  };
+  const seen = new Set<KeyModifier>();
+  const out: KeyModifier[] = [];
+  for (const m of modifiers) {
+    const c = canon[m];
+    if (!seen.has(c)) {
+      seen.add(c);
+      out.push(c);
+    }
+  }
+  return out;
+}
+
+export function registerPressKey(
+  server: McpServer,
+  getSurfaces: SurfaceGetter,
+): void {
+  server.registerTool(
+    "press_key",
+    {
+      title: "Press key",
+      description:
+        "Dispatch a keyboard key (with optional modifiers) to the focused " +
+        "renderer element. Use for named keys like Enter/Escape/arrows or " +
+        "combos like Cmd+Enter. For text entry use `type_text`.",
+      inputSchema,
+    },
+    async ({ surface, key, modifiers = [] }) => {
+      const session = getOrAttachSession(getSurfaces, surface);
+      const normalizedModifiers = normalizeModifiers(modifiers);
+      const cdpKey = keyToCdp(key, normalizedModifiers);
+      const mask = modifiersToMask(normalizedModifiers);
+
+      // keyDown carries `text`; keyUp doesn't.
+      await session.send("Input.dispatchKeyEvent", {
+        type: "keyDown",
+        modifiers: mask,
+        ...cdpKey,
+      });
+      await session.send("Input.dispatchKeyEvent", {
+        type: "keyUp",
+        modifiers: mask,
+        key: cdpKey.key,
+        code: cdpKey.code,
+        windowsVirtualKeyCode: cdpKey.windowsVirtualKeyCode,
+      });
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Pressed ${normalizedModifiers.length ? `${normalizedModifiers.join("+")}+` : ""}${key} on ${surface}`,
+          },
+        ],
+        structuredContent: { surface, key, modifiers: normalizedModifiers },
+      };
+    },
+  );
+}

--- a/src/tools/query-dom.ts
+++ b/src/tools/query-dom.ts
@@ -1,0 +1,173 @@
+// Single `Runtime.evaluate` round-trip rather than the DOM-domain
+// nodeId/objectId chain (~10x fewer calls).
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { getOrAttachSession } from "../cdp.js";
+import type { SurfaceGetter } from "../surfaces.js";
+
+const inputSchema = {
+  surface: z.string().min(1).describe("Which surface to query."),
+  selector: z
+    .string()
+    .min(1)
+    .describe(
+      "CSS selector. Up to `limit` matches (default 50) are returned; see " +
+        "`truncated` + `totalFound` in the result to detect when more exist.",
+    ),
+  attrs: z
+    .array(z.string())
+    .max(20)
+    .optional()
+    .describe(
+      'Attribute names to include per match (max 20). Defaults to ["id", ' +
+        '"class", "data-testid", "aria-label", "role", "href", "name", "type"]. ' +
+        "Upper bound prevents query amplification when a caller passes a huge list.",
+    ),
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .max(200)
+    .optional()
+    .describe(
+      "Cap on matches returned (1–200). Defaults to 50. Bounds the " +
+        "serialized response size — note that the browser still runs " +
+        "`querySelectorAll` in full internally, so `limit` doesn't " +
+        "prevent the query cost itself; for that use a more specific " +
+        "selector than `*`. `timeoutMs` is the real runaway guard.",
+    ),
+  timeoutMs: z
+    .number()
+    .int()
+    .positive()
+    .max(60_000)
+    .optional()
+    .describe(
+      "CDP Runtime.evaluate timeout in ms (1-60000). Defaults to 5000. " +
+        "Guards against a runaway selector hanging the tool.",
+    ),
+};
+
+const DEFAULT_ATTRS = [
+  "id",
+  "class",
+  "data-testid",
+  "aria-label",
+  "role",
+  "href",
+  "name",
+  "type",
+];
+
+interface RuntimeEvaluateResult {
+  result: { type: string; value?: unknown };
+  exceptionDetails?: { text: string; exception?: { description?: string } };
+}
+
+export function registerQueryDom(
+  server: McpServer,
+  getSurfaces: SurfaceGetter,
+): void {
+  server.registerTool(
+    "query_dom",
+    {
+      title: "Query DOM",
+      description:
+        "Return a compact JSON array of elements matching a CSS selector — " +
+        "tag, text content, selected attributes, bounding rect. Use this " +
+        "before `click`/`type_text` to confirm the selector is right. " +
+        "Note: `text` comes from `textContent`/`value` and is not filtered " +
+        "for visibility — `display:none`/`visibility:hidden` text still " +
+        "appears. The `visible` flag (computed from the bounding rect) is " +
+        "the right thing to gate on if you only want on-screen matches.",
+      inputSchema,
+    },
+    async ({
+      surface,
+      selector,
+      attrs = DEFAULT_ATTRS,
+      limit = 50,
+      timeoutMs = 5000,
+    }) => {
+      const session = getOrAttachSession(getSurfaces, surface);
+
+      // Report `totalFound` alongside the bounded `matches` slice so
+      // the caller can distinguish "count equals limit exactly" from
+      // truncation.
+      const expression = `(() => {
+        const nodes = Array.from(document.querySelectorAll(${JSON.stringify(selector)}));
+        const totalFound = nodes.length;
+        const sliced = nodes.slice(0, ${limit});
+        return {
+          totalFound,
+          matches: sliced.map((el) => {
+            const r = el.getBoundingClientRect();
+            const attrObj = {};
+            for (const name of ${JSON.stringify(attrs)}) {
+              const v = el.getAttribute(name);
+              if (v !== null) {
+                // Cap per-value at 200 chars so a giant class/data-
+                // attribute can't dominate the response.
+                attrObj[name] = v.length > 200 ? v.slice(0, 200) + "…" : v;
+              }
+            }
+            // Form controls expose state via .value, not textContent.
+            const rawText =
+              el instanceof HTMLInputElement ||
+              el instanceof HTMLTextAreaElement ||
+              el instanceof HTMLSelectElement
+                ? el.value
+                : (el.textContent ?? "");
+            return {
+              tag: el.tagName.toLowerCase(),
+              text: String(rawText).trim().slice(0, 200),
+              attrs: attrObj,
+              rect: { x: r.x, y: r.y, width: r.width, height: r.height },
+              visible: r.width > 0 && r.height > 0,
+            };
+          }),
+        };
+      })()`;
+
+      const res = (await session.send("Runtime.evaluate", {
+        expression,
+        returnByValue: true,
+        timeout: timeoutMs, // pathological-selector guard
+      })) as RuntimeEvaluateResult;
+
+      if (res.exceptionDetails) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: `query_dom threw: ${res.exceptionDetails.exception?.description ?? res.exceptionDetails.text}`,
+            },
+          ],
+        };
+      }
+
+      const payload = (res.result.value ?? { totalFound: 0, matches: [] }) as {
+        totalFound: number;
+        matches: unknown[];
+      };
+      const truncated = payload.totalFound > payload.matches.length;
+      return {
+        content: [
+          {
+            type: "text",
+            text: `${payload.matches.length} match(es) for ${selector}${truncated ? ` (of ${payload.totalFound} total — truncated at limit ${limit})` : ""}\n${JSON.stringify(payload.matches, null, 2)}`,
+          },
+        ],
+        structuredContent: {
+          surface,
+          selector,
+          matches: payload.matches,
+          totalFound: payload.totalFound,
+          truncated,
+        },
+      };
+    },
+  );
+}

--- a/src/tools/reload-surface.ts
+++ b/src/tools/reload-surface.ts
@@ -1,0 +1,67 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { resolveSurface, type SurfaceGetter } from "../surfaces.js";
+import { awaitNextLoad } from "./wait-for-load.js";
+
+const inputSchema = {
+  surface: z.string().min(1).describe("Which surface to reload."),
+  ignoreCache: z
+    .boolean()
+    .optional()
+    .describe(
+      "If true, bypass the HTTP cache (maps to reloadIgnoringCache). " +
+        "Defaults to false — Vite's dev server rarely serves stale content.",
+    ),
+  timeoutMs: z
+    .number()
+    .int()
+    .positive()
+    .max(60_000)
+    .optional()
+    .describe("Max wait for did-finish-load (1-60000 ms). Defaults to 10000."),
+};
+
+export function registerReloadSurface(
+  server: McpServer,
+  getSurfaces: SurfaceGetter,
+): void {
+  server.registerTool(
+    "reload_surface",
+    {
+      title: "Reload surface",
+      description:
+        "Reload a surface's renderer and wait for did-finish-load. Blocks " +
+        "until the new load completes so subsequent tools see the fresh " +
+        "renderer. Use ignoreCache to bypass the HTTP cache.",
+      inputSchema,
+    },
+    async ({ surface, ignoreCache = false, timeoutMs = 10_000 }) => {
+      const win = resolveSurface(getSurfaces, surface);
+      const wc = win.webContents;
+
+      const result = await awaitNextLoad(
+        wc,
+        () => {
+          if (ignoreCache) wc.reloadIgnoringCache();
+          else wc.reload();
+        },
+        timeoutMs,
+      );
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Reloaded ${surface} in ${result.durationMs}ms (ignoreCache=${ignoreCache})`,
+          },
+        ],
+        structuredContent: {
+          surface,
+          ignoreCache,
+          durationMs: result.durationMs,
+          url: wc.getURL(),
+        },
+      };
+    },
+  );
+}

--- a/src/tools/screenshot.ts
+++ b/src/tools/screenshot.ts
@@ -1,0 +1,86 @@
+// `webContents.capturePage()` (not CDP `Page.captureScreenshot`):
+// no debugger attach, transparent regions stay transparent, PNG is
+// byte-deterministic across runs.
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { resolveSurface, type SurfaceGetter } from "../surfaces.js";
+
+const rectSchema = z.object({
+  x: z.number().int().nonnegative(),
+  y: z.number().int().nonnegative(),
+  width: z.number().int().positive(),
+  height: z.number().int().positive(),
+});
+
+const inputSchema = {
+  surface: z.string().min(1).describe("Which surface to screenshot."),
+  rect: rectSchema
+    .optional()
+    .describe(
+      "Optional crop rectangle in renderer CSS pixels (relative to the " +
+        "surface's content area). Omit to capture the whole surface.",
+    ),
+};
+
+export function registerScreenshot(
+  server: McpServer,
+  getSurfaces: SurfaceGetter,
+): void {
+  server.registerTool(
+    "screenshot",
+    {
+      title: "Screenshot surface",
+      description:
+        "Capture a PNG of a floating surface's rendered content. Returns " +
+        "an image content block Claude can view directly. Transparent " +
+        "regions stay transparent (no OS compositor backdrop).",
+      inputSchema,
+    },
+    async ({ surface, rect }) => {
+      const win = resolveSurface(getSurfaces, surface);
+      const image = rect
+        ? await win.webContents.capturePage(rect)
+        : await win.webContents.capturePage();
+
+      // Empty NativeImage = the webContents hasn't painted yet.
+      if (image.isEmpty()) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text:
+                `Surface "${surface}" captured as an empty image — the renderer ` +
+                `probably hasn't painted yet. Call show_surface first, or ` +
+                `await a DOM-ready signal via evaluate before retrying.`,
+            },
+          ],
+        };
+      }
+
+      const png = image.toPNG();
+      const size = image.getSize();
+
+      return {
+        content: [
+          {
+            type: "image",
+            mimeType: "image/png",
+            data: png.toString("base64"),
+          },
+          {
+            type: "text",
+            text: `${surface}: ${size.width}×${size.height} px, ${png.byteLength} bytes`,
+          },
+        ],
+        structuredContent: {
+          surface,
+          width: size.width,
+          height: size.height,
+          byteLength: png.byteLength,
+        },
+      };
+    },
+  );
+}

--- a/src/tools/show-surface.ts
+++ b/src/tools/show-surface.ts
@@ -1,0 +1,53 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { resolveSurface, type SurfaceGetter } from "../surfaces.js";
+
+const inputSchema = {
+  surface: z.string().min(1).describe("Which surface to show."),
+  focus: z
+    .boolean()
+    .optional()
+    .describe(
+      "Whether to focus the window after showing it. Defaults to true.",
+    ),
+};
+
+export function registerShowSurface(
+  server: McpServer,
+  getSurfaces: SurfaceGetter,
+): void {
+  server.registerTool(
+    "show_surface",
+    {
+      title: "Show surface",
+      description: "Make a floating surface visible and (optionally) focus it.",
+      inputSchema,
+    },
+    async ({ surface, focus = true }) => {
+      const win = resolveSurface(getSurfaces, surface);
+      win.show();
+
+      if (focus) {
+        win.focus();
+      }
+      // Sample after the optional focus() so `focus: false` still
+      // reports the real state.
+      const focused = win.isFocused();
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Shown ${surface}. visible=${win.isVisible()} focused=${focused}`,
+          },
+        ],
+        structuredContent: {
+          surface,
+          visible: win.isVisible(),
+          focused,
+          focusable: win.isFocusable(),
+        },
+      };
+    },
+  );
+}

--- a/src/tools/type-text.ts
+++ b/src/tools/type-text.ts
@@ -1,0 +1,97 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { getOrAttachSession } from "../cdp.js";
+import { waitForSelector } from "../cdp-helpers.js";
+import type { SurfaceGetter } from "../surfaces.js";
+
+const inputSchema = {
+  surface: z.string().min(1).describe("Which surface to type into."),
+  text: z.string().describe("Text to insert at the current caret position."),
+  selector: z
+    .string()
+    .min(1)
+    .optional()
+    .describe(
+      "Optional: focus this element before inserting. If omitted, text " +
+        "goes to whichever element currently has focus. Empty string is " +
+        'rejected at schema time — pass undefined, not "".',
+    ),
+  timeoutMs: z
+    .number()
+    .int()
+    .positive()
+    .max(60_000)
+    .optional()
+    .describe("Wait-for-selector timeout in ms (1-60000). Defaults to 5000."),
+};
+
+export function registerTypeText(
+  server: McpServer,
+  getSurfaces: SurfaceGetter,
+): void {
+  server.registerTool(
+    "type_text",
+    {
+      title: "Type text into input",
+      description:
+        "Insert text at the caret. If a selector is given, focus that " +
+        "element first. Uses CDP Input.insertText so React controlled " +
+        "inputs receive `input` events. Use press_key for single keys " +
+        "that trigger keyDown handlers (Enter, Escape, arrows, etc.).",
+      inputSchema,
+    },
+    async ({ surface, text, selector, timeoutMs = 5000 }) => {
+      const session = getOrAttachSession(getSurfaces, surface);
+
+      if (selector) {
+        await waitForSelector(session, selector, timeoutMs);
+
+        // Verify activeElement after focus — a disabled input or
+        // non-HTMLElement match would otherwise silently eat the
+        // focus and `insertText` would hit the wrong field.
+        const focusRes = (await session.send("Runtime.evaluate", {
+          expression: `(() => {
+            const el = document.querySelector(${JSON.stringify(selector)});
+            if (!el || !(el instanceof HTMLElement)) return false;
+            el.focus();
+            return document.activeElement === el;
+          })()`,
+          returnByValue: true,
+          timeout: timeoutMs,
+        })) as {
+          result?: { value?: boolean };
+          exceptionDetails?: {
+            text: string;
+            exception?: { description?: string };
+          };
+        };
+
+        if (focusRes.exceptionDetails) {
+          const exc = focusRes.exceptionDetails;
+          throw new Error(
+            `type_text focus evaluation threw: ${exc.exception?.description ?? exc.text}`,
+          );
+        }
+        if (focusRes.result?.value !== true) {
+          throw new Error(
+            `type_text could not focus selector "${selector}" — element not an HTMLElement, disabled, or stole focus elsewhere`,
+          );
+        }
+      }
+
+      await session.send("Input.insertText", { text });
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: selector
+              ? `Typed ${text.length} char(s) into ${selector} on ${surface}`
+              : `Typed ${text.length} char(s) into focused element on ${surface}`,
+          },
+        ],
+        structuredContent: { surface, selector, charsTyped: text.length },
+      };
+    },
+  );
+}

--- a/src/tools/wait-for-load.ts
+++ b/src/tools/wait-for-load.ts
@@ -1,0 +1,151 @@
+// Also exports `awaitNextLoad` (used by `reload_surface`). Uses
+// Electron's `did-finish-load` / `did-fail-load` events rather than
+// CDP `Page.loadEventFired` — no debugger-attach round-trip needed.
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { WebContents } from "electron";
+import { z } from "zod";
+import { resolveSurface, type SurfaceGetter } from "../surfaces.js";
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+// Filters subframe failures + ERR_ABORTED (-3) — both are
+// false-positive signals (redirects, downloads, etc.).
+function attachLoadListeners(
+  webContents: WebContents,
+  timeoutMs: number,
+  started: number,
+  onLoaded: (durationMs: number) => void,
+  onFailed: (msg: string) => void,
+): { cleanup: () => void } {
+  const onLoad = (): void => {
+    cleanup();
+    onLoaded(performance.now() - started);
+  };
+  const onFail = (
+    _event: Electron.Event,
+    errorCode: number,
+    errorDescription: string,
+    _validatedURL: string,
+    isMainFrame: boolean,
+  ): void => {
+    if (!isMainFrame || errorCode === -3) return;
+    cleanup();
+    onFailed(`load failed (${errorCode}): ${errorDescription}`);
+  };
+  const onTimeout = (): void => {
+    cleanup();
+    onFailed(`load did not finish within ${timeoutMs}ms`);
+  };
+
+  const timer = setTimeout(onTimeout, timeoutMs);
+  const cleanup = (): void => {
+    clearTimeout(timer);
+    webContents.off("did-finish-load", onLoad);
+    webContents.off("did-fail-load", onFail);
+  };
+
+  webContents.once("did-finish-load", onLoad);
+  // `on` (not `once`): EventEmitter unregisters `once` listeners
+  // before the handler runs, so the first ignored event would kill
+  // the listener. `cleanup` does the explicit `off`.
+  webContents.on("did-fail-load", onFail);
+
+  return { cleanup };
+}
+
+// Listeners attach BEFORE `action` runs so we can't miss a
+// synchronous event. `performance.now()` (monotonic) for duration.
+export function awaitNextLoad(
+  webContents: WebContents,
+  action: () => void,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+): Promise<{ status: "loaded"; durationMs: number }> {
+  return new Promise((resolve, reject) => {
+    const { cleanup } = attachLoadListeners(
+      webContents,
+      timeoutMs,
+      performance.now(),
+      (durationMs) => resolve({ status: "loaded", durationMs }),
+      (msg) => reject(new Error(msg)),
+    );
+
+    try {
+      action();
+    } catch (err) {
+      cleanup();
+      reject(err);
+    }
+  });
+}
+
+// Listeners attach BEFORE `isLoading()` — a naive
+// isLoading-then-attach has a TOCTOU race that would hang to timeout.
+function waitForLoadIfActive(
+  webContents: WebContents,
+  timeoutMs: number,
+): Promise<
+  { status: "already-loaded" } | { status: "loaded"; durationMs: number }
+> {
+  return new Promise((resolve, reject) => {
+    const { cleanup } = attachLoadListeners(
+      webContents,
+      timeoutMs,
+      performance.now(),
+      (durationMs) => resolve({ status: "loaded", durationMs }),
+      (msg) => reject(new Error(msg)),
+    );
+
+    // If `onLoad` already settled (load finished between attach and
+    // this check), the second resolve is a no-op.
+    if (!webContents.isLoading()) {
+      cleanup();
+      resolve({ status: "already-loaded" });
+    }
+  });
+}
+
+const inputSchema = {
+  surface: z.string().min(1).describe("Which surface to wait on."),
+  timeoutMs: z
+    .number()
+    .int()
+    .positive()
+    .max(60_000)
+    .optional()
+    .describe("Max wait (1-60000 ms). Defaults to 10000."),
+};
+
+export function registerWaitForLoad(
+  server: McpServer,
+  getSurfaces: SurfaceGetter,
+): void {
+  server.registerTool(
+    "wait_for_load",
+    {
+      title: "Wait for surface load",
+      description:
+        "Block until the surface's webContents finishes loading. " +
+        "Short-circuits when no load is in progress — useful when " +
+        "something external (link click, OAuth redirect) may have " +
+        "triggered a navigation and you want to sync before inspecting.",
+      inputSchema,
+    },
+    async ({ surface, timeoutMs = DEFAULT_TIMEOUT_MS }) => {
+      const win = resolveSurface(getSurfaces, surface);
+      const result = await waitForLoadIfActive(win.webContents, timeoutMs);
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              result.status === "already-loaded"
+                ? `${surface} was already loaded (no wait needed)`
+                : `${surface} finished loading in ${result.durationMs}ms`,
+          },
+        ],
+        structuredContent: { surface, ...result },
+      };
+    },
+  );
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,10 @@
+// Public types sub-export — `@nebula-agents/electron-mcp/types`.
+//
+// Consumers that build `ToolDef`s in a separate package (or want to
+// strongly type the surface map their app exposes) can import from this
+// path without pulling in the runtime entry. Kept to *types only* so
+// the import is zero-cost at bundle time.
+
+export type { ElectronMcpServerHandle } from "./index.js";
+export type { SurfaceGetter, SurfaceMap } from "./surfaces.js";
+export type { ToolDef } from "./tool-def.js";

--- a/tests/fixtures/electron-main.cjs
+++ b/tests/fixtures/electron-main.cjs
@@ -1,0 +1,85 @@
+// Minimal Electron main process for the smoke test.
+//
+// Boots a hidden BrowserWindow that loads a tiny inline HTML page, then
+// starts an embedded `electron-mcp` server bound to an ephemeral port.
+// Prints `MCP_URL=<url>` on a fresh line so the Playwright-side test can
+// parse the kernel-assigned URL out of stdout.
+//
+// Why CommonJS: passing a `.mjs` entry to Electron 41 doesn't enter
+// main-process mode (`process.type` is undefined and `require("electron")`
+// returns the binary path string instead of the runtime APIs). Sticking
+// to CJS for the entry; we still pull in the ESM-only `dist/index.js`
+// via dynamic `import()`.
+//
+// The fixture imports the *built* package output (../../dist/index.js).
+// `pnpm test:smoke` runs `pnpm build` first so dist is fresh.
+
+const { app, BrowserWindow } = require("electron");
+const path = require("node:path");
+
+// Minimal renderer payload — enough for `screenshot` to capture a
+// non-empty image and for `evaluate` to have a real `document`.
+const PAGE_HTML = `
+<!doctype html>
+<html>
+<head><meta charset="utf-8"><title>electron-mcp smoke fixture</title></head>
+<body style="margin:0;background:#1e9bff;color:#fff;font-family:system-ui">
+  <main style="padding:24px"><h1>electron-mcp smoke fixture</h1></main>
+</body>
+</html>
+`;
+
+async function main() {
+  await app.whenReady();
+
+  const win = new BrowserWindow({
+    width: 320,
+    height: 240,
+    show: false,
+    webPreferences: {
+      // Smoke test only — disable nodeIntegration so `evaluate`'s
+      // "main world doesn't see Node" guarantee holds.
+      nodeIntegration: false,
+      contextIsolation: true,
+    },
+  });
+
+  // `did-finish-load` is the cleanest signal for `screenshot` to
+  // capture something non-empty; `loadURL("data:…")` resolves before
+  // first paint on some platforms.
+  const loaded = new Promise((resolve) => {
+    win.webContents.once("did-finish-load", resolve);
+  });
+  await win.loadURL(
+    `data:text/html;charset=utf-8,${encodeURIComponent(PAGE_HTML)}`,
+  );
+  await loaded;
+  // Give the compositor a tick to actually paint pixels — capturePage
+  // returns an empty image if called before the first frame lands.
+  await new Promise((r) => setTimeout(r, 100));
+
+  // dist/index.js is ESM, so dynamic-import from CJS.
+  const distEntry = path.resolve(__dirname, "..", "..", "dist", "index.js");
+  const { createElectronMcpServer } = await import(distEntry);
+
+  const server = createElectronMcpServer({
+    getSurfaces: () => ({ main: win }),
+    // Ephemeral port — the test reads the bound URL from stdout.
+    port: 0,
+    serverInfo: { name: "electron-mcp-smoke-fixture", version: "0.0.0" },
+  });
+  await server.start();
+  if (!server.url) throw new Error("server.url was null after start()");
+
+  // Newline-bounded so the test's regex doesn't snag on a partial line.
+  process.stdout.write(`MCP_URL=${server.url}\n`);
+
+  app.on("window-all-closed", () => {
+    server.stop().finally(() => app.quit());
+  });
+}
+
+main().catch((err) => {
+  console.error("[fixture] startup failed:", err);
+  process.exit(1);
+});

--- a/tests/fixtures/package.json
+++ b/tests/fixtures/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "electron-mcp-smoke-fixture",
+  "private": true,
+  "version": "0.0.0",
+  "main": "electron-main.cjs",
+  "description": "Minimal Electron app the smoke test launches via Playwright's _electron.launch(). Electron only enters main-process mode when it can resolve a package.json with a `main` field; pointing it at this directory does that without dragging the parent package's `type: module` into scope."
+}

--- a/tests/smoke.electron.test.ts
+++ b/tests/smoke.electron.test.ts
@@ -1,0 +1,123 @@
+// Tracer-bullet smoke test for `@nebula-agents/electron-mcp`.
+//
+// This test launches a real Electron app via Playwright's `_electron`,
+// boots an MCP server inside it via `createElectronMcpServer`, then drives
+// three tools end-to-end through the public HTTP transport:
+//
+//   1. `list_surfaces`  — returns the configured surface keys
+//   2. `evaluate`       — runs JS in the renderer main world
+//   3. `screenshot`     — returns a PNG of the surface
+//
+// Anything that talks to the SDK / debugger / loopback HTTP path inside
+// the package runs for real. The only fixture is the consumer-side
+// Electron main script that wires our public API to a hidden window.
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { expect, test } from "@playwright/test";
+import { _electron as electron, type ElectronApplication } from "playwright";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+// Pass the *directory* (not the file) so Electron resolves the
+// fixture's `package.json#main` and enters main-process mode. Pointing
+// it at the .cjs file directly leaves `app`/`BrowserWindow` undefined.
+const FIXTURE_DIR = path.join(__dirname, "fixtures");
+
+// Helper: read fixture stdout until the `MCP_URL=…` line our fixture
+// prints when the server is listening. Times out via Playwright's
+// per-test timeout if the line never arrives.
+function waitForMcpUrl(app: ElectronApplication): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const proc = app.process();
+    let buf = "";
+    const onData = (chunk: Buffer | string) => {
+      buf += chunk.toString();
+      const match = buf.match(/MCP_URL=(\S+)/);
+      if (match?.[1]) {
+        proc.stdout?.off("data", onData);
+        resolve(match[1]);
+      }
+    };
+    proc.stdout?.on("data", onData);
+    proc.once("exit", (code) => {
+      if (!buf.includes("MCP_URL=")) {
+        reject(
+          new Error(
+            `fixture exited (code ${code}) before printing MCP_URL.\n` +
+              `stdout so far:\n${buf}`,
+          ),
+        );
+      }
+    });
+  });
+}
+
+test("MCP server drives a real Electron surface end-to-end", async () => {
+  // `ELECTRON_RUN_AS_NODE=1` forces Electron to behave like plain Node
+  // (no `app`/`BrowserWindow`); some shells set it for tooling reasons.
+  // Strip it from the spawned env so this test isn't shell-dependent.
+  const { ELECTRON_RUN_AS_NODE: _, ...cleanEnv } = process.env;
+  const app = await electron.launch({
+    args: [FIXTURE_DIR],
+    env: { ...cleanEnv, ELECTRON_DISABLE_SANDBOX: "1" },
+  });
+
+  try {
+    const url = await waitForMcpUrl(app);
+    expect(url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/mcp$/);
+
+    const client = new Client(
+      { name: "electron-mcp-smoke", version: "0.0.0" },
+      { capabilities: {} },
+    );
+    const transport = new StreamableHTTPClientTransport(new URL(url));
+    await client.connect(transport);
+
+    try {
+      // --- list_surfaces ----------------------------------------------
+      const list = await client.callTool({
+        name: "list_surfaces",
+        arguments: {},
+      });
+      expect(list.isError).toBeFalsy();
+      const listed = (list.structuredContent ?? {}) as {
+        surfaces?: Array<{ surface: string; present: boolean }>;
+      };
+      const present = (listed.surfaces ?? [])
+        .filter((s) => s.present)
+        .map((s) => s.surface);
+      expect(present).toEqual(["main"]);
+
+      // --- evaluate ---------------------------------------------------
+      const evaluated = await client.callTool({
+        name: "evaluate",
+        arguments: { surface: "main", expression: "1 + 1" },
+      });
+      expect(evaluated.isError).toBeFalsy();
+      const evalText = (evaluated.content as Array<{ type: string; text?: string }>)
+        .find((c) => c.type === "text")?.text;
+      expect(evalText).toBe("2");
+
+      // --- screenshot -------------------------------------------------
+      const shot = await client.callTool({
+        name: "screenshot",
+        arguments: { surface: "main" },
+      });
+      expect(shot.isError).toBeFalsy();
+      const image = (shot.content as Array<{ type: string; data?: string; mimeType?: string }>)
+        .find((c) => c.type === "image");
+      expect(image?.mimeType).toBe("image/png");
+      expect(image?.data).toBeTruthy();
+      // Base64 of a non-empty PNG decodes to at least the 8-byte signature
+      // plus an IHDR chunk — well over 30 bytes once base64-encoded.
+      expect((image?.data ?? "").length).toBeGreaterThan(40);
+    } finally {
+      await client.close();
+    }
+  } finally {
+    await app.close();
+  }
+});

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noUncheckedIndexedAccess": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "tests"]
+}


### PR DESCRIPTION
## Summary

- Imports the cleaned-up MCP server from `nebula-desktop/src/background/mcp/` (excluding app-specific tools): index, server, cdp, cdp-helpers, surfaces, tool-def + 14 generic tools. Edits to imported code: dropped `@util/log` (replaced with a small console logger so this package has zero internal-tooling deps), generalized `SERVER_INSTRUCTIONS` and made it / the `McpServer` name configurable via `createElectronMcpServer({ instructions, serverInfo })`, and added `.js` extensions on relative imports for NodeNext ESM.
- Adds a `@nebula-agents/electron-mcp/types` sub-export re-exporting `ElectronMcpServerHandle`, `SurfaceGetter`, `SurfaceMap`, `ToolDef` (zero-cost, types-only).
- Adds `tests/smoke.electron.test.ts` — first end-to-end test: launches a fixture Electron app via Playwright `_electron`, spins up the MCP server, connects an MCP client over StreamableHTTP, drives `list_surfaces` + `evaluate` + `screenshot` against a real hidden `BrowserWindow`. Strips `ELECTRON_RUN_AS_NODE` from the spawned env so the test isn't shell-dependent. Fixture is a CJS mini-app under `tests/fixtures/` with its own `package.json` (Electron 41 only enters main-process mode when it resolves `package.json#main`, and the parent `"type": "module"` fights the `require`-based entry otherwise).

Refs #153.

## Test plan

- [ ] `pnpm playwright test` runs the smoke test green against a real BrowserWindow on CI.
- [ ] Build (`tsc -p tsconfig.build.json`) emits without errors.
- [ ] `@nebula-agents/electron-mcp` and `@nebula-agents/electron-mcp/types` resolve from a downstream consumer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Release

* **New Features**
  * Introduced `@nebula-agents/electron-mcp` package, an Electron Model Context Protocol server enabling programmatic control of Electron windows
  * Added 15+ tools including: click, type, hover, screenshot, query DOM, accessibility inspection, form filling, window management, and keyboard input

* **Tests**
  * Added Playwright-based smoke tests validating MCP server functionality with Electron

<!-- end of auto-generated comment: release notes by coderabbit.ai -->