### PR TITLE
chore: rewrite PR template to match real scripts + Changesets flow

### DIFF
--- a/.changeset/pr-template-rewrite.md
+++ b/.changeset/pr-template-rewrite.md
@@ -1,0 +1,4 @@
+---
+---
+
+Repo meta: rewrite `.github/pull_request_template.md` to reference real `pnpm` scripts (`typecheck`, `test:unit`, `test:smoke`) and the Changesets release flow. No user-visible change.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,10 +2,11 @@
 Thanks for opening a PR. Fill the sections below so reviewers can land
 this without context-switching.
 
-CI runs typecheck + lint + unit tests + the Playwright `_electron` smoke
-test on every PR. Releases happen via Changesets — when this PR lands on
-`main`, the `release` workflow opens (or updates) a "Version Packages"
-PR consolidating pending changesets. Merging that PR cuts a release.
+CI runs `pnpm check` (lint + typecheck + test + build) and the Playwright
+`_electron` smoke test (`pnpm test:electron`) on every PR. Releases happen
+via Changesets — when this PR lands on `main`, the release workflow opens
+(or updates) a "Version Packages" PR consolidating pending changesets.
+Merging that PR cuts a release.
 
 See CONTRIBUTING.md for the full flow.
 -->
@@ -26,11 +27,10 @@ input schema, adjusting the loopback bind / HTTP defaults). -->
 
 ## Verification
 
-- [ ] `pnpm typecheck` passes locally
-- [ ] `pnpm test:unit` passes locally
-- [ ] If this touches CDP wiring or any bundled tool, `pnpm test:smoke` passes
+- [ ] `pnpm check` passes locally (lint + typecheck + test + build)
+- [ ] If this touches CDP wiring or any bundled tool, `pnpm test:electron` passes
 - [ ] A changeset is staged (`.changeset/<name>.md`) **or** this PR is genuinely no-op for users (`pnpm changeset --empty`)
-- [ ] Public API changes (`src/index.ts` / `src/types.ts` exports) are reflected in `README.md`
+- [ ] Public API changes (exports from `src/index.ts`) are reflected in `README.md`
 - [ ] No secrets, tokens, or `.env*` files included
 
 ## Notes for reviewers

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,41 @@
+<!--
+Thanks for opening a PR. Fill the sections below so reviewers can land
+this without context-switching.
+
+CI runs typecheck + lint + unit tests + the Playwright `_electron` smoke
+test on every PR. Releases happen via Changesets — when this PR lands on
+`main`, the `release` workflow opens (or updates) a "Version Packages"
+PR consolidating pending changesets. Merging that PR cuts a release.
+
+See CONTRIBUTING.md for the full flow.
+-->
+
 ## Summary
+
+<!-- One to three sentences: what changes and why. Link the issue if
+there is one (e.g. "Closes #42"). -->
+
+## Changes
+
+<!-- Bulleted list of concrete changes. Call out anything subtle
+(broadening a public type, touching CDP wiring, changing a tool's
+input schema, adjusting the loopback bind / HTTP defaults). -->
+
+-
+-
 
 ## Verification
 
-- [ ] `pnpm check`
-- [ ] `pnpm test:electron` if Electron/CDP behavior changed
+- [ ] `pnpm typecheck` passes locally
+- [ ] `pnpm test:unit` passes locally
+- [ ] If this touches CDP wiring or any bundled tool, `pnpm test:smoke` passes
+- [ ] A changeset is staged (`.changeset/<name>.md`) **or** this PR is genuinely no-op for users (`pnpm changeset --empty`)
+- [ ] Public API changes (`src/index.ts` / `src/types.ts` exports) are reflected in `README.md`
+- [ ] No secrets, tokens, or `.env*` files included
+
+## Notes for reviewers
+
+<!-- Anything not obvious from the diff: trade-offs considered,
+alternatives rejected, follow-ups intentionally left out. For
+security-sensitive changes, please flag explicitly — see SECURITY.md
+for the vuln disclosure process. -->


### PR DESCRIPTION
## Summary

The existing `.github/pull_request_template.md` is a 5-line stub. Replace it with a structured template (Summary / Changes / Verification / Notes for reviewers) that points contributors at the Changesets workflow and the README-update expectation for public API changes.

This is the last bit of repo-docs scaffolding called out in the PR C deliverables for [agent-labs-dev/nebula-desktop#153](https://github.com/agent-labs-dev/nebula-desktop/issues/153).

## Changes

- Rewrite `.github/pull_request_template.md`:
  - Add Summary / Changes / Notes-for-reviewers sections (only Summary + Verification existed before)
  - Verification checklist references `pnpm check` and `pnpm test:electron` (matches `package.json` and `CONTRIBUTING.md`)
  - Add a "changeset staged or empty" item so contributors don't break the release workflow
  - Add a "public API change reflected in README" item
  - Add a "no secrets / .env" item
- Add an empty changeset (`.changeset/pr-template-rewrite.md`) since this is repo meta

## Verification

- [x] No source/test changes; CI `check` and `electron-smoke` jobs unaffected
- [x] Empty changeset staged per `CONTRIBUTING.md` (Releases section)
- [x] Script names cross-checked against `package.json` (`pnpm check`, `pnpm test:electron`)
- [x] No secrets, tokens, or `.env*` files included

## Notes for reviewers

The verification checklist intentionally mirrors what `CONTRIBUTING.md` already says, so contributors don't have to keep two lists in sync mentally. If you'd rather have the template stay terse and lean on `CONTRIBUTING.md` for the checklist, happy to slim it back down.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request template with enhanced author guidance and a more detailed verification checklist requiring explicit local checks (lint/typecheck/tests/build) and conditional smoke tests
  * Added a "Notes for reviewers" section for contextual and security-sensitive callouts
  * Added a changeset configuration entry to document release/process expectations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->