### PR TITLE
ci: attach release job to npm-publish environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: npm-publish
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary

- npm Trusted Publisher for `@nebula-agents/electron-mcp` is configured with **Environment name: `npm-publish`**, but the release job had no `environment:` key. The OIDC token therefore lacked the environment claim and `pnpm changeset publish` was rejected with E404 (run [25026312815](https://github.com/agent-labs-dev/electron-mcp/actions/runs/25026312815)).
- Adds `environment: npm-publish` to the `release` job so the OIDC claims match what npm expects.
- Requires the `npm-publish` GitHub Actions environment to exist in repo settings (Settings → Environments). Once created, the next push to `main` (or rerun of the failing workflow) should publish 0.1.0.

## Verification

- [ ] `pnpm check`
- [ ] `pnpm test:electron` if Electron/CDP behavior changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow infrastructure configuration for deployment environment management. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->